### PR TITLE
[yelly] step-1 index.html 응답

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="corretto-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # be-was-2024
 코드스쿼드 백엔드 교육용 WAS 2024 개정판
+
+# 기능 구현 리스트
+- [x] 요청 헤더(GET/Host/Connection/Accept)에 대해 파싱하고 로그로 출력할 수 있다
+- [x] 'localhost:8080/index.html' 요청에 대해 정적 html을 응답할 수 있다

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # be-was-2024
 코드스쿼드 백엔드 교육용 WAS 2024 개정판
 
+# GitHub Wiki
+- 학습 내용 정리: [WAS1 - Wiki](https://github.com/Yeriimii/be-was-neon/wiki/Java-Concurrent-%E2%80%90-CompletableFuture)
+
 # 기능 구현 리스트
 - [x] 요청 헤더(GET/Host/Connection/Accept)에 대해 파싱하고 로그로 출력할 수 있다
 - [x] 'localhost:8080/index.html' 요청에 대해 정적 html을 응답할 수 있다

--- a/src/main/java/utils/RequestHeaderParser.java
+++ b/src/main/java/utils/RequestHeaderParser.java
@@ -1,0 +1,22 @@
+package utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RequestHeaderParser {
+    private static final Logger logger = LoggerFactory.getLogger(RequestHeaderParser.class);
+
+    public static String requestParse(String line) {
+        if (line.startsWith("GET")) {
+            logger.debug(line);
+            return line.split(" ")[1];
+        } else if (line.startsWith("Host")) {
+            logger.debug(line);
+        } else if (line.startsWith("Connection")) {
+            logger.debug(line);
+        } else if (line.startsWith("Accept:")) {
+            logger.debug(line);
+        }
+        return "";
+    }
+}

--- a/src/main/java/utils/RequestHeaderParser.java
+++ b/src/main/java/utils/RequestHeaderParser.java
@@ -1,22 +1,51 @@
 package utils;
 
+import static utils.RequestHeaderParser.ParseString.*;
+
+import java.util.Arrays;
+import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class RequestHeaderParser {
     private static final Logger logger = LoggerFactory.getLogger(RequestHeaderParser.class);
+    private static final int URL_INDEX = 1;
+    private static final UnaryOperator<String> REQUEST_URL_PARSE = header -> header.startsWith(GET.value)
+            ? header.split(BLANK.value)[URL_INDEX] : EMPTY.value;
+    private static final Consumer<String> TARGET_LOGGER = header -> {
+        if (isTargetLogger(header)) {
+            logger.debug("[REQUEST-HEADER] {}", header);
+        }
+    };
 
     public static String requestParse(String line) {
-        if (line.startsWith("GET")) {
-            logger.debug(line);
-            return line.split(" ")[1];
-        } else if (line.startsWith("Host")) {
-            logger.debug(line);
-        } else if (line.startsWith("Connection")) {
-            logger.debug(line);
-        } else if (line.startsWith("Accept:")) {
-            logger.debug(line);
+        TARGET_LOGGER.accept(line);
+
+        return REQUEST_URL_PARSE.apply(line);
+    }
+
+    public enum ParseString {
+        EMPTY(""),
+        BLANK(" "),
+        GET("GET"),
+        HOST("Host"),
+        CONNECTION("Connection"),
+        ACCEPT("Accept:"),
+        ;
+
+        private final String value;
+
+        ParseString(String value) {
+            this.value = value;
         }
-        return "";
+
+        public static boolean isTargetLogger(String header) {
+            return Arrays.stream(values())
+                    .filter(target -> !target.equals(EMPTY))
+                    .map(target -> target.value)
+                    .anyMatch(header::startsWith);
+        }
     }
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -1,8 +1,14 @@
 package webserver;
 
+import static utils.RequestHeaderParser.*;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.Socket;
 
@@ -11,6 +17,7 @@ import org.slf4j.LoggerFactory;
 
 public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
+    private static final String RESOURCE_PATH = System.getProperty("user.dir") + "/src/main/resources/static";
 
     private Socket connection;
 
@@ -24,10 +31,18 @@ public class RequestHandler implements Runnable {
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
+            BufferedReader reader = new BufferedReader(new InputStreamReader(in, "UTF-8"));
             DataOutputStream dos = new DataOutputStream(out);
-            byte[] body = "<h1>Hello World</h1>".getBytes();
-            response200Header(dos, body.length);
-            responseBody(dos, body);
+
+            String line = reader.readLine();
+            String request = requestParse(line);
+            while (!line.isEmpty()) {
+                if (request.endsWith(".html")) {
+                    responseHtml(dos, RESOURCE_PATH + request);
+                }
+                line = reader.readLine();
+                request = requestParse(line);
+            }
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
@@ -50,6 +65,30 @@ public class RequestHandler implements Runnable {
             dos.flush();
         } catch (IOException e) {
             logger.error(e.getMessage());
+        }
+    }
+
+    private void responseHtml(DataOutputStream dos, String path) {
+        try (
+                FileInputStream fileInputStream = new FileInputStream(path);
+                ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        ) {
+            int bytesRead;
+            byte[] buffer = new byte[1024];
+
+            // HTML 파일을 읽어 ByteArrayOutputStream에 쓰기
+            while ((bytesRead = fileInputStream.read(buffer)) != -1) {
+                byteArrayOutputStream.write(buffer, 0, bytesRead);
+            }
+
+            // ByteArrayOutputStream의 내용을 바이트 배열로 가져오기
+            byte[] fileBytes = byteArrayOutputStream.toByteArray();
+
+            // DataOutputStream으로 변환하여 반환
+            response200Header(dos, fileBytes.length);
+            responseBody(dos, fileBytes);
+        } catch (IOException e) {
+            e.printStackTrace();
         }
     }
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
 
 public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
-    private static final String RESOURCE_PATH = System.getProperty("user.dir") + "/src/main/resources/static";
+    private static final String RESOURCE_PATH = "./src/main/resources/static";
 
     private Socket connection;
 

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -18,6 +18,8 @@ import org.slf4j.LoggerFactory;
 public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
     private static final String RESOURCE_PATH = "./src/main/resources/static";
+    private static final String HTML_EXTENSION = ".html";
+    private static final int BUFFER_SIZE = 1024;
 
     private Socket connection;
 
@@ -30,18 +32,18 @@ public class RequestHandler implements Runnable {
                 connection.getPort());
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
-            // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
             BufferedReader reader = new BufferedReader(new InputStreamReader(in, "UTF-8"));
             DataOutputStream dos = new DataOutputStream(out);
 
             String line = reader.readLine();
-            String request = requestParse(line);
-            while (!line.isEmpty()) {
-                if (request.endsWith(".html")) {
+            while (line != null && !line.isEmpty()) {
+                String request = requestParse(line);
+
+                if (request.endsWith(HTML_EXTENSION)) {
                     responseHtml(dos, RESOURCE_PATH + request);
                 }
+
                 line = reader.readLine();
-                request = requestParse(line);
             }
         } catch (IOException e) {
             logger.error(e.getMessage());
@@ -74,15 +76,15 @@ public class RequestHandler implements Runnable {
                 ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         ) {
             int bytesRead;
-            byte[] buffer = new byte[1024];
+            byte[] buffer = new byte[BUFFER_SIZE];
 
             // HTML 파일을 읽어 ByteArrayOutputStream에 쓰기
-            while ((bytesRead = fileInputStream.read(buffer)) != -1) {
-                byteArrayOutputStream.write(buffer, 0, bytesRead);
+            while ((bytesRead = fileInputStream.read(buffer)) != -1) { // 더 이상 읽지 못하면 -1을 반환 -> 루프 종료
+                byteArrayOutputStream.write(buffer, 0, bytesRead); // buffer 배열의 0번째부터 읽은 바이트 수 만큼 작성
             }
 
             // ByteArrayOutputStream의 내용을 바이트 배열로 가져오기
-            byte[] fileBytes = byteArrayOutputStream.toByteArray();
+            byte[] fileBytes = byteArrayOutputStream.toByteArray();  // 모든 html 내용이 쓰여져 있음 (메모리에 올라온 상태)
 
             // DataOutputStream으로 변환하여 반환
             response200Header(dos, fileBytes.length);

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -3,6 +3,9 @@ package webserver;
 import java.net.ServerSocket;
 import java.net.Socket;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,6 +21,9 @@ public class WebServer {
             port = Integer.parseInt(args[0]);
         }
 
+        // ThreadPool 생성
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+
         // 서버소켓을 생성한다. 웹서버는 기본적으로 8080번 포트를 사용한다.
         try (ServerSocket listenSocket = new ServerSocket(port)) {
             logger.info("Web Application Server started {} port.", port);
@@ -25,8 +31,8 @@ public class WebServer {
             // 클라이언트가 연결될때까지 대기한다.
             Socket connection;
             while ((connection = listenSocket.accept()) != null) {
-                Thread thread = new Thread(new RequestHandler(connection));
-                thread.start();
+                CompletableFuture<Void> requestFuture = CompletableFuture.runAsync(new RequestHandler(connection), executor);
+                requestFuture.join();
             }
         }
     }

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -31,9 +31,10 @@ public class WebServer {
             // 클라이언트가 연결될때까지 대기한다.
             Socket connection;
             while ((connection = listenSocket.accept()) != null) {
-                CompletableFuture<Void> requestFuture = CompletableFuture.runAsync(new RequestHandler(connection), executor);
-                requestFuture.join();
+                CompletableFuture.runAsync(new RequestHandler(connection), executor);
             }
+        } finally {
+            executor.shutdown(); // 서버 종료 시 스레드 풀 종료
         }
     }
 }

--- a/src/test/java/utils/RequestHeaderParserTest.java
+++ b/src/test/java/utils/RequestHeaderParserTest.java
@@ -1,0 +1,22 @@
+package utils;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RequestHeaderParserTest {
+
+    @DisplayName("GET 요청에 대해 header를 파싱하면 요청한 URL을 반환한다")
+    @Test
+    void requestParse() {
+        // given
+        String url = "GET /index.html HTTP/1.1";
+
+        // when
+        String request = RequestHeaderParser.requestParse(url);
+
+        // then
+        assertThat(request).isEqualTo("/index.html");
+    }
+}


### PR DESCRIPTION
## 구현 내용
- HTTP 요청에 대해 GET, Host, Connection, Accept 4가지만 파싱하는 util 클래스를 구현했습니다.
  - 현재 요구사항에선 캐시, Accept language 등을 사용하지 않기 때문에 4가지만 파싱하도록 구현했습니다.
- 정적 리소스 파일의 위치(`src/main/resources`)를 상수로 갖도록 해서 파싱한 url에 해당하는 리소스를 찾기 쉽게 구현했습니다.
- 요청한 html 파일로 응답할 때 html 파일을 읽어 DataOutputStream에 입력하는 메서드를 구현했습니다.
- 비동기 작업으로 변경 할 때 SingleThreadPool을 이용해 HTTP 요청을 순차적으로 처리할 수 있도록 구현했습니다.

## 고민 사항
- html 파일을 반환할 때 css 파일이나 jpg같은 이미지 파일에 대해 Response Header에 Content-Type을 동적으로 입력하는 방식을 고려하고 있습니다.

## 기타
- [GitHub Wiki - CompletableFuture 정리](https://github.com/Yeriimii/be-was-neon/wiki/Java-Concurrent-%E2%80%90-CompletableFuture#completeasync) 이 곳에 학습한 내용을 정리했습니다.