### PR TITLE
[실브] step-2 GET으로 회원가입

### DIFF
--- a/src/main/java/utils/ParameterParser.java
+++ b/src/main/java/utils/ParameterParser.java
@@ -1,0 +1,17 @@
+package utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ParameterParser {
+
+    public static Map<String, String> getUserInfo(String input) {
+        Map<String, String> userInfo = new HashMap<>();
+        for (String parameter : input.split("&")) {
+            String[] entry = parameter.split("=");
+            userInfo.put(entry[0], entry[1]);
+        }
+
+        return userInfo;
+    }
+}

--- a/src/main/java/utils/ParameterParser.java
+++ b/src/main/java/utils/ParameterParser.java
@@ -1,17 +1,25 @@
 package utils;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.Map;
 
 public class ParameterParser {
 
-    public static Map<String, String> getUserInfo(String input) {
-        Map<String, String> userInfo = new HashMap<>();
-        for (String parameter : input.split("&")) {
-            String[] entry = parameter.split("=");
-            userInfo.put(entry[0], entry[1]);
+    public static Map<String, String> getUserParams(String input) {
+        Map<String, String> params = new HashMap<>();
+        for (String param : input.split("&")) {
+            String[] keyValue = param.split("=");
+            try {
+                String key = keyValue[0];
+                String value = URLDecoder.decode(keyValue[1], "UTF-8");
+                params.put(key, value);
+            } catch (UnsupportedEncodingException e) {
+                e.printStackTrace();
+            }
         }
 
-        return userInfo;
+        return params;
     }
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -11,6 +11,7 @@ public class RequestHandler implements Runnable {
 
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
     private static final String STATIC_RESOURCES_PATH = "src/main/resources/static";
+    private static final String COMMON_FILE = "/index.html";
 
     private final Socket connection;
 
@@ -33,7 +34,7 @@ public class RequestHandler implements Runnable {
             }
 
             // 파일 읽기
-            String url = STATIC_RESOURCES_PATH + RequestLineParser.extractPath(requestBuilder.toString());
+            String url = redirect(STATIC_RESOURCES_PATH + RequestLineParser.extractPath(requestBuilder.toString()));
             byte[] body;
             try (FileInputStream fileInputStream = new FileInputStream(url)) {
                 body = fileInputStream.readAllBytes();
@@ -47,6 +48,13 @@ public class RequestHandler implements Runnable {
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
+    }
+
+    private String redirect(String originalUrl) {
+        if (originalUrl.endsWith(COMMON_FILE)) {
+            return originalUrl;
+        }
+        return originalUrl + COMMON_FILE;
     }
 
     private void response200Header(DataOutputStream dos, int lengthOfBodyContent) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -51,13 +51,13 @@ public class RequestHandler implements Runnable {
     }
 
     private User parseUser(String requestPath) {
-        Map<String, String> userInfo = ParameterParser.getUserInfo(validateCreateUserPath(requestPath));
+        Map<String, String> userInfo = ParameterParser.getUserParams(validateCreateUserPath(requestPath));
         return new User(userInfo.get("userId"), userInfo.get("password"), userInfo.get("name"), userInfo.get("email"));
     }
 
     private String validateCreateUserPath(String createUserPath) {
         String[] pathAndInfo = createUserPath.split("\\?");
-        if (!pathAndInfo[0].equals("/user/create")) {
+        if (pathAndInfo.length != 2 || !pathAndInfo[0].equals("/user/create")) {
             throw new IllegalArgumentException("INVALID PATH");
         }
         return pathAndInfo[1];

--- a/src/main/resources/static/registration/index.html
+++ b/src/main/resources/static/registration/index.html
@@ -30,26 +30,35 @@
               class="input_textfield"
               name="userId"
               placeholder="아이디를 입력해주세요"
-              autocomplete="username"
-            />
-          </div>
-          <div class="textfield textfield_size_s">
-            <p class="title_textfield">닉네임</p>
-            <input
-              class="input_textfield"
-              name="nickname"
-              placeholder="닉네임을 입력해주세요"
-              autocomplete="username"
+              autocomplete="userId"
             />
           </div>
           <div class="textfield textfield_size_s">
             <p class="title_textfield">비밀번호</p>
             <input
+                class="input_textfield"
+                type="password"
+                name="password"
+                placeholder="비밀번호를 입력해주세요"
+                autocomplete="current-password"
+            />
+          </div>
+          <div class="textfield textfield_size_s">
+            <p class="title_textfield">이름</p>
+            <input
               class="input_textfield"
-              type="password"
-              name="password"
-              placeholder="비밀번호를 입력해주세요"
-              autocomplete="current-password"
+              name="name"
+              placeholder="이름을 입력해주세요"
+              autocomplete="name"
+            />
+          </div>
+          <div class="textfield textfield_size_s">
+            <p class="title_textfield">이메일</p>
+            <input
+                class="input_textfield"
+                name="email"
+                placeholder="이메일을 입력해주세요"
+                autocomplete="email"
             />
           </div>
           <button

--- a/src/main/resources/static/registration/index.html
+++ b/src/main/resources/static/registration/index.html
@@ -23,11 +23,12 @@
       </header>
       <div class="page">
         <h2 class="page-title">회원가입</h2>
-        <form class="form">
+        <form class="form" action="/user/create" method="GET">
           <div class="textfield textfield_size_s">
             <p class="title_textfield">아이디</p>
             <input
               class="input_textfield"
+              name="userId"
               placeholder="아이디를 입력해주세요"
               autocomplete="username"
             />
@@ -36,6 +37,7 @@
             <p class="title_textfield">닉네임</p>
             <input
               class="input_textfield"
+              name="nickname"
               placeholder="닉네임을 입력해주세요"
               autocomplete="username"
             />
@@ -45,6 +47,7 @@
             <input
               class="input_textfield"
               type="password"
+              name="password"
               placeholder="비밀번호를 입력해주세요"
               autocomplete="current-password"
             />
@@ -53,7 +56,7 @@
             id="registration-btn"
             class="btn btn_contained btn_size_m"
             style="margin-top: 24px"
-            type="button"
+            type="submit"
           >
             회원가입
           </button>

--- a/src/test/java/utils/ParameterParserTest.java
+++ b/src/test/java/utils/ParameterParserTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class ParameterParserTest {
+  
+}

--- a/src/test/java/utils/ParameterParserTest.java
+++ b/src/test/java/utils/ParameterParserTest.java
@@ -1,4 +1,22 @@
-import static org.junit.jupiter.api.Assertions.*;
+package utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 class ParameterParserTest {
-  
+
+    @Test
+    @DisplayName("사용자 정보를 담은 문자열 파싱 후 parameter 추출 기능 검증")
+    void getUserInfo() {
+        String input = "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net";
+        Map<String, String> userInfo = ParameterParser.getUserParams(input);
+
+        assertThat(userInfo.get("userId")).isEqualTo("javajigi");
+        assertThat(userInfo.get("password")).isEqualTo("password");
+        assertThat(userInfo.get("name")).isEqualTo("%EB%B0%95%EC%9E%AC%EC%84%B1");
+        assertThat(userInfo.get("email")).isEqualTo("javajigi%40slipp.net");
+    }
 }


### PR DESCRIPTION

## 구현 내용
#### ✅ GET으로 회원가입 기능 구현

- **접근 경로 리다이렉트**
  - “회원가입” 메뉴를 클릭 시 http://localhost:8080/registration.html 로 이동하지만, 실제 요청하는 폼의 경로는 /registration/index.html
  - `redirect`(String path) : 접근 경로가 "/index.html" 을 포함하지 않을 경우 뒷부분에 연결한 경로로 접근하도록 수정

- **회원가입 폼에서 버튼 클릭 시 입력값 서버 전달**
  - 사용자 정보가 포함된 HTTP Request가 서버로 전달되도록 폼 문서 수정 (/registration/index.html)
    - 이메일 필드 추가, form 태그(action, method[GET]) 수정, 각 input 태그의 name 추가, button 태그(type[submit]) 수정

- **사용자(User) 입력값 파싱**
  - **ParameterParser**.`getUserParams`() : User 생성자 파라미터 값 추출
    - **String**.`split`() 메서드 호출 : 사용자 입력값을 각 파라미터별로 분리 (파싱)
    - **URLDecoder**.`decode`() 메서드 호출 : URL에서 인코딩된 값을 디코딩하여 일반 텍스트로 변환

- **사용자(User) 생성 및 저장**
  - `parseUser`() : 사용자 파라미터를 생성자 매개변수로 대입하여 객체 생성
  - **Database**.`addUser`() : 데이터베이스에 해당 객체 저장

## 고민 사항

## 기타
