### PR TITLE
[제이든] step-2 웹 서버 2단계 - GET으로 회원가입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ repositories {
 
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: '5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
 
     implementation 'ch.qos.logback:logback-classic:1.2.3'

--- a/src/main/java/model/User.java
+++ b/src/main/java/model/User.java
@@ -1,16 +1,15 @@
 package model;
 
 public class User {
+
     private String userId;
     private String password;
-    private String name;
-    private String email;
+    private String nickName;
 
-    public User(String userId, String password, String name, String email) {
+    public User(String userId, String password, String nickName) {
         this.userId = userId;
         this.password = password;
-        this.name = name;
-        this.email = email;
+        this.nickName = nickName;
     }
 
     public String getUserId() {
@@ -21,16 +20,12 @@ public class User {
         return password;
     }
 
-    public String getName() {
-        return name;
-    }
-
-    public String getEmail() {
-        return email;
+    public String getNickName() {
+        return nickName;
     }
 
     @Override
     public String toString() {
-        return "User [userId=" + userId + ", password=" + password + ", name=" + name + ", email=" + email + "]";
+        return "User [userId=" + userId + ", password=" + password + ", nickName=" + nickName + "]";
     }
 }

--- a/src/main/java/webserver/HttpRequest.java
+++ b/src/main/java/webserver/HttpRequest.java
@@ -1,0 +1,23 @@
+package webserver;
+
+public class HttpRequest {
+
+    private String method;
+    private String requestURI;
+
+
+    public HttpRequest(String requestLine) {
+        String[] requestLines = requestLine.split(" ");
+        method = requestLines[0];
+        requestURI = requestLines[1];
+
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public String getRequestURI() {
+        return requestURI;
+    }
+}

--- a/src/main/java/webserver/HttpRequest.java
+++ b/src/main/java/webserver/HttpRequest.java
@@ -1,16 +1,26 @@
 package webserver;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 public class HttpRequest {
 
     private String method;
     private String requestURI;
 
+    private final Map<String, String> queries = new HashMap<>();
 
     public HttpRequest(String requestLine) {
         String[] requestLines = requestLine.split(" ");
         method = requestLines[0];
-        requestURI = requestLines[1];
-
+        if (hasQueryParameter(requestLines[1])) {
+            extractQueryFromURI(requestLines[1]);
+        } else {
+            requestURI = requestLines[1];
+        }
     }
 
     public String getMethod() {
@@ -20,4 +30,36 @@ public class HttpRequest {
     public String getRequestURI() {
         return requestURI;
     }
+
+    private boolean hasQueryParameter(String requestLine) {
+        return requestLine.contains("?");
+    }
+
+    private void extractQueryFromURI(String URI) {
+        String[] URIs = URI.split("\\?");
+        requestURI = URIs[0];
+        queries = parseQueryString(URIs[1]);
+    }
+
+    private Map<String, String> parseQueryString(String string) {
+        Map<String, String> queryMap = new HashMap<>();
+
+        String[] pairs = string.split("&");
+
+        for (String pair : pairs) {
+
+            String[] keyValue = pair.split("=");
+
+            String key = keyValue[0];
+            String value = URLDecoder.decode(keyValue[1], StandardCharsets.UTF_8);
+
+            queryMap.put(key, value);
+        }
+        return queryMap;
+    }
+
+    public Map<String, String> getQueries() {
+        return Collections.unmodifiableMap(queries);
+    }
+
 }

--- a/src/main/java/webserver/HttpRequest.java
+++ b/src/main/java/webserver/HttpRequest.java
@@ -11,7 +11,7 @@ public class HttpRequest {
     private String method;
     private String requestURI;
 
-    private final Map<String, String> queries = new HashMap<>();
+    private Map<String, String> queries = new HashMap<>();
 
     public HttpRequest(String requestLine) {
         String[] requestLines = requestLine.split(" ");

--- a/src/main/java/webserver/HttpRequest.java
+++ b/src/main/java/webserver/HttpRequest.java
@@ -62,4 +62,8 @@ public class HttpRequest {
         return Collections.unmodifiableMap(queries);
     }
 
+    public String getValue(String key) {
+        return getQueries().get(key);
+    }
+
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -114,7 +114,10 @@ public class RequestHandler implements Runnable {
     public byte[] readByteFromFile(File file) {
         try (FileInputStream fileInputStream = new FileInputStream(file);) {
             ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-            byteArrayOutputStream.write(fileInputStream.readAllBytes());
+            int bytes;
+            while ((bytes = fileInputStream.read()) != -1) {
+                byteArrayOutputStream.write(bytes);
+            }
             return byteArrayOutputStream.toByteArray();
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -35,6 +35,7 @@ public class RequestHandler implements Runnable {
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             BufferedReader inputRequest = new BufferedReader(new InputStreamReader(in));
             String requestLine = readRequestLine(inputRequest);
+            String headerLine = readHeaderLine(inputRequest);
             String path = extractPathFromRequestLine(requestLine);
 
             File file = new File(DEFAULT_RESOURCE_PATH + path);
@@ -103,6 +104,19 @@ public class RequestHandler implements Runnable {
         }
 
         return requestBuilder.toString();
+    }
+
+    private String readHeaderLine(BufferedReader httpRequest) throws IOException {
+        StringBuilder requestHeaderBuilder = new StringBuilder();
+        String line;
+
+        while ((line = httpRequest.readLine()) != null && !line.isEmpty()) {
+            requestHeaderBuilder.append(line).append('\n');
+            logger.debug("Header Line: {}", line);
+        }
+
+        return requestHeaderBuilder.toString();
+
     }
 
     public String extractPathFromRequestLine(String httpMessage) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -17,8 +17,11 @@ import org.slf4j.LoggerFactory;
 public class RequestHandler implements Runnable {
 
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
+    private static final String DEFAULT_RESOURCE_PATH = "src/main/resources/static";
+    private static final String INDEX_FILE_NAME = "index.html";
 
-    private Socket connection;
+
+    private final Socket connection;
 
     public RequestHandler(Socket connectionSocket) {
         this.connection = connectionSocket;
@@ -34,10 +37,10 @@ public class RequestHandler implements Runnable {
             String requestLine = readRequestLine(inputRequest);
             String path = extractPathFromRequestLine(requestLine);
 
-            File file = new File("src/main/resources/static" + path);
+            File file = new File(DEFAULT_RESOURCE_PATH + path);
 
             if (file.isDirectory()) {
-                file = new File(file, "index.html");
+                file = new File(file, INDEX_FILE_NAME);
             }
 
             HttpRequest httpRequest = new HttpRequest(requestLine);

--- a/src/main/resources/static/registration/index.html
+++ b/src/main/resources/static/registration/index.html
@@ -1,64 +1,70 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link href="../reset.css" rel="stylesheet" />
-    <link href="../global.css" rel="stylesheet" />
-  </head>
-  <body>
-    <div class="container">
-      <header class="header">
-        <a href="/"><img src="../img/signiture.svg" /></a>
-        <ul class="header__menu">
-          <li class="header__menu__item">
-            <a class="btn btn_contained btn_size_s" href="/login">로그인</a>
-          </li>
-          <li class="header__menu__item">
-            <a class="btn btn_ghost btn_size_s" href="/registration">
-              회원 가입
-            </a>
-          </li>
-        </ul>
-      </header>
-      <div class="page">
-        <h2 class="page-title">회원가입</h2>
-        <form class="form">
-          <div class="textfield textfield_size_s">
-            <p class="title_textfield">아이디</p>
-            <input
-              class="input_textfield"
-              placeholder="아이디를 입력해주세요"
-              autocomplete="username"
-            />
-          </div>
-          <div class="textfield textfield_size_s">
-            <p class="title_textfield">닉네임</p>
-            <input
-              class="input_textfield"
-              placeholder="닉네임을 입력해주세요"
-              autocomplete="username"
-            />
-          </div>
-          <div class="textfield textfield_size_s">
-            <p class="title_textfield">비밀번호</p>
-            <input
-              class="input_textfield"
-              type="password"
-              placeholder="비밀번호를 입력해주세요"
-              autocomplete="current-password"
-            />
-          </div>
-          <button
-            id="registration-btn"
-            class="btn btn_contained btn_size_m"
-            style="margin-top: 24px"
-            type="button"
-          >
-            회원가입
-          </button>
-        </form>
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <link href="../reset.css" rel="stylesheet"/>
+  <link href="../global.css" rel="stylesheet"/>
+</head>
+<body>
+<div class="container">
+  <header class="header">
+    <a href="/"><img src="../img/signiture.svg"/></a>
+    <ul class="header__menu">
+      <li class="header__menu__item">
+        <a class="btn btn_contained btn_size_s" href="/login">로그인</a>
+      </li>
+      <li class="header__menu__item">
+        <a class="btn btn_ghost btn_size_s" href="/registration">
+          회원 가입
+        </a>
+      </li>
+    </ul>
+  </header>
+  <div class="page">
+    <h2 class="page-title">회원가입</h2>
+    <form id="registration-form" class="form" action="/create" method="GET">
+      <div class="textfield textfield_size_s">
+        <p class="title_textfield">아이디</p>
+        <input
+            id="userId"
+            name="userId"
+            class="input_textfield"
+            placeholder="아이디를 입력해주세요"
+            autocomplete="username"
+        />
       </div>
-    </div>
-  </body>
+      <div class="textfield textfield_size_s">
+        <p class="title_textfield">닉네임</p>
+        <input
+            id="nickname"
+            name="nickname"
+            class="input_textfield"
+            placeholder="닉네임을 입력해주세요"
+            autocomplete="username"
+        />
+      </div>
+      <div class="textfield textfield_size_s">
+        <p class="title_textfield">비밀번호</p>
+        <input
+            id="password"
+            name="password"
+            class="input_textfield"
+            type="password"
+            placeholder="비밀번호를 입력해주세요"
+            autocomplete="current-password"
+        />
+      </div>
+      <button
+          id="registration-btn"
+          class="btn btn_contained btn_size_m"
+          style="margin-top: 24px"
+          type="submit"
+      >
+        회원가입
+      </button>
+    </form>
+  </div>
+</div>
+</body>
 </html>

--- a/src/test/java/webserver/HttpRequestTest.java
+++ b/src/test/java/webserver/HttpRequestTest.java
@@ -1,0 +1,29 @@
+package webserver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class HttpRequestTest {
+
+    private HttpRequest httpRequest;
+
+    @BeforeEach
+    void setUp() {
+        httpRequest = new HttpRequest("GET /registration HTTP/1.1");
+    }
+
+    @Test
+    @DisplayName("RequestLine으로부터 Method를 잘 파싱하는지 테스트")
+    void getMethodFromRequestLine() {
+        assertThat(httpRequest.getMethod()).isEqualTo("GET");
+    }
+
+    @Test
+    @DisplayName("RequestLine으로부터 URI를 잘 파싱하는지 테스트")
+    void getURIFromRequestLine() {
+        assertThat(httpRequest.getRequestURI()).isEqualTo("/registration");
+    }
+}

--- a/src/test/java/webserver/HttpRequestTest.java
+++ b/src/test/java/webserver/HttpRequestTest.java
@@ -2,9 +2,12 @@ package webserver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class HttpRequestTest {
 
@@ -26,4 +29,24 @@ class HttpRequestTest {
     void getURIFromRequestLine() {
         assertThat(httpRequest.getRequestURI()).isEqualTo("/registration");
     }
+
+    @Test
+    @DisplayName("query parameter가 있을 때 path를 파싱하는 테스트")
+    void extractPathFromURI() {
+        httpRequest = new HttpRequest(
+            "GET /create?userId=jayden&nickname=%EC%A0%9C%EC%9D%B4%EB%93%A0&password=1234 HTTP/1.1");
+        assertThat(httpRequest.getRequestURI()).isEqualTo("/create");
+    }
+
+
+    @ParameterizedTest
+    @CsvSource({"userId, jayden", "nickname, 제이든", "password, 1234"})
+    @DisplayName("query parameter가 있을 때 query를 파싱하는 테스트")
+    void extractQueryFromURI(String key, String value) {
+        httpRequest = new HttpRequest(
+            "GET /create?userId=jayden&nickname=%EC%A0%9C%EC%9D%B4%EB%93%A0&password=1234 HTTP/1.1");
+        Map<String, String> queries = httpRequest.getQueries();
+        assertThat(queries.get(key)).isEqualTo(value);
+    }
 }
+

--- a/src/test/java/webserver/HttpRequestTest.java
+++ b/src/test/java/webserver/HttpRequestTest.java
@@ -3,6 +3,7 @@ package webserver;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
+import model.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -47,6 +48,16 @@ class HttpRequestTest {
             "GET /create?userId=jayden&nickname=%EC%A0%9C%EC%9D%B4%EB%93%A0&password=1234 HTTP/1.1");
         Map<String, String> queries = httpRequest.getQueries();
         assertThat(queries.get(key)).isEqualTo(value);
+    }
+
+    @Test
+    @DisplayName("HttpRequest객체로부터 파라미터를 불러와서 User 객체가 잘 만들어지는지 테스트")
+    void testCreateUserFromQueryParms() {
+        httpRequest = new HttpRequest(
+            "GET /create?userId=jayden&nickname=%EC%A0%9C%EC%9D%B4%EB%93%A0&password=1234 HTTP/1.1");
+        User user = new User(httpRequest.getValue("userId"),
+            httpRequest.getValue("nickName"), httpRequest.getValue("password"));
+        assertThat(user.getUserId()).isEqualTo("jayden");
     }
 }
 


### PR DESCRIPTION
## 구현 과정

- 회원가입 버튼이 안눌리던 문제를 html파일을 수정해서 해결했습니다.
- HTTP Request를 더 쉽게 관리하기 위해서 httpRequest클래스를 구현했습니다. 이를 통해서 기존에 path만 파싱할 수 있던 기능에 나아가 query 정보까지 얻을 수 있습니다.
- 회원가입이 완료되면 /index.html로 redirect 해주는 302 response 메서드를 구현했습니다.

## 고민한점
### step1 리뷰 반영 사항
- 기존에 있던 readAllBytes()를 삭제하고 while 반목문을 통해서 파일을 읽고 이를 byteArray로 바꿔줬습니다. output stream은  `ByteArrayOutputStream`를 사용했습니다.
- index 파일 이름이나 resource 폴더의 경로를 상수로 표현했습니다. 여기서 경로를 절대주소를 사용해야 할지 상대경로를 사용해야 하는지 고민을 했습니다. 우선 현재 프로젝트는 개인 프로젝트이기 때문에 절대경로나 상대경로 모두 사용해도 무방하다고 느꼈습니다. 그러나 다른 사람들과 같이 진행할 경우(웹 서버가 가동되어있고 image 파일등이 저장되어 있을 때) html파일이 자주 이동이 될 때 여기에 링크되어 있는 image,css파일등의 경로는 절대경로를 사용하는 것이 좋다고 느꼈습니다.

### step2 고민
- query문이 있는 request를 받는 경우 회원 정보를 User 객체에 저장을 했습니다. 이 때 http request가 쿼리문을 포함하고 있는지 확인 하는 과정을 `if (path.startswith("/create")`로 정했는데 더 좋은 방법이 있는지 궁금합니다.
- 회원가입이 완료되면 200 response가 아니라 302 response를 던져서 /index.html로 redirect 해줬습니다. 현재는 2개의 response만 다루고 있지만 후에 response가 더 늘어나면 httpResponse라는 클래스를 만들어서 관리해도 좋다고 느꼈습니다.

## 질문
- 현재 요구사항은 GET으로 회원가입 정보를 서버로 보내줬는데 이런 경우 URL에 비밀번호 같은 중요한 정보가 노출되지 않나요? POST를 쓰는게 더 좋은 방법이지 않나요?