### PR TITLE
[샤피] 웹 서버 1단계 -  index.html 응답

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # be-was-2024
 코드스쿼드 백엔드 교육용 WAS 2024 개정판
+
+## Web Server 구현 1
+- 웹 서버 1단계 - index.html 응답
+
+### 학습 내용
+[소켓, 입출력 스트림, 프로세스와 스레드](https://github.com/sharpie1330/be-was-neon/wiki/%EC%86%8C%EC%BC%93,-%EC%9E%85%EC%B6%9C%EB%A0%A5-%EC%8A%A4%ED%8A%B8%EB%A6%BC,-%ED%94%84%EB%A1%9C%EC%84%B8%EC%8A%A4%EC%99%80-%EC%8A%A4%EB%A0%88%EB%93%9C)
+- New Client Connect! Connected IP : {}, Port : {} 로그 메시지에서 포트 번호가 매번 바뀌는 이유
+  - 클라이언트 측에서 요청을 보낼 때 운영체제가 동적으로 포트를 할당해 준다. 요청을 보낸 해당 포트로 응답을 보내면 된다.
+  - 서버 측에서는 8080포트로 지정해 주었기 때문에 해당 포트로 항상 listen 중. 이 어플리케이션을 구분하는 포트 번호가 8080이다.
+
+### 구현 내용
+- 요청의 첫 줄을 읽으면 GET과 같은 request method와 request url, HTTP/1.1과 같은 프로토콜 순서로 표시된다. 
+- 따라서 해당 request line의 request url과 method를 파싱해 로거로 출력했다.
+- request url에는 클라이언트가 GET을 요청하는 경로가 담겨있고, 해당 파일의 확장자에 따라 ContentType을 다르게 처리해 응답해주어야 한다.
+- 우선 해당 경로의 파일을 찾아 바이트 배열로 읽고, 파일의 확장자로 MimeType을 결정한다. 이때 nio 라이브러리를 사용하지 않기 위해 FileInputStream 클래스를 사용해 구현했다.
+- MimeType은 enum 클래스로 만들어서 파일의 확장자와 같은 이름의 enum 상수가 있으면 해당 상수의 mimeType값을 구할 수 있도록 했다.

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
 
-    implementation 'ch.qos.logback:logback-classic:1.2.3'
+    implementation 'ch.qos.logback:logback-classic:1.4.14'
     testImplementation 'org.assertj:assertj-core:3.16.1'
 
 

--- a/src/main/java/utils/MIMEType.java
+++ b/src/main/java/utils/MIMEType.java
@@ -1,0 +1,26 @@
+package utils;
+
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+
+public enum MIMEType {
+    svg("image/svg+xml"),
+    ico("image/vnd.microsoft.icon"),
+    css("text/css"),
+    html("text/html"),
+    png("image/png");
+
+    private final String mimeType;
+
+    MIMEType(String mimeType) {
+        this.mimeType = mimeType;
+    }
+
+    public static String getContentType(String extension) {
+        return Arrays.stream(MIMEType.values())
+                .filter(m -> m.name().equals(extension))
+                .findAny()
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 파일 확장자입니다."))
+                .mimeType;
+    }
+}

--- a/src/main/java/utils/MIMEType.java
+++ b/src/main/java/utils/MIMEType.java
@@ -16,7 +16,7 @@ public enum MIMEType {
         this.mimeType = mimeType;
     }
 
-    public static String getContentType(String extension) {
+    public static String getMimeType(String extension) {
         return Arrays.stream(MIMEType.values())
                 .filter(m -> m.name().equals(extension))
                 .findAny()

--- a/src/main/java/utils/StringUtils.java
+++ b/src/main/java/utils/StringUtils.java
@@ -1,0 +1,13 @@
+package utils;
+
+public class StringUtils {
+    private static final String NEW_LINE = "\r\n";
+
+    private StringUtils() {
+
+    }
+
+    public static String appendNewLine(String origin) {
+        return origin + NEW_LINE;
+    }
+}

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -58,7 +58,7 @@ public class RequestHandler implements Runnable {
         try (FileInputStream fileIn = new FileInputStream(file)){
             byte[] body = new byte[(int) file.length()];
             int readLen = fileIn.read(body);
-            String mimeType = getMimeType(file);
+            String mimeType = getMimeType(file.getName());
             response200Header(dos, readLen, mimeType);
             responseBody(dos, body);
         } catch (IOException e) {
@@ -66,10 +66,9 @@ public class RequestHandler implements Runnable {
         }
     }
 
-    private String getMimeType(File file) {
-        String fileName = file.getName();
+    private String getMimeType(String fileName) {
         String extension = fileName.substring(fileName.lastIndexOf(".") + 1);
-        return MIMEType.getContentType(extension);
+        return MIMEType.getMimeType(extension);
     }
 
     private void response200Header(DataOutputStream dos, int lengthOfBodyContent, String mimeType) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -5,6 +5,7 @@ import java.net.Socket;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import utils.MIMEType;
 
 import static utils.StringUtils.*;
 
@@ -20,15 +21,9 @@ public class RequestHandler implements Runnable {
     public void run() {
         logger.debug("New Client Connect! Connected IP : {}, Port : {}", connection.getInetAddress(),
                 connection.getPort());
-
-        final String DEFAULT_PATH = "src/main/resources/static/";
-        final String INDEX_HTML = "index.html";
-        File file = new File(DEFAULT_PATH.concat(INDEX_HTML));
-
         try (
                 InputStream in = connection.getInputStream();
-                OutputStream out = connection.getOutputStream();
-                FileInputStream fileIn = new FileInputStream(file)
+                OutputStream out = connection.getOutputStream()
         ) {
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
             BufferedReader br = new BufferedReader(new InputStreamReader(in, "UTF-8"));
@@ -40,7 +35,9 @@ public class RequestHandler implements Runnable {
             }
 
             String[] tokens = line.split(" ");
-            logger.debug("request Method : {}, request Url : {}", tokens[0], tokens[1]);
+            String requestMethod = tokens[0];
+            String requestUrl = tokens[1];
+            logger.debug("request Method : {}, request Url : {}", requestMethod, requestUrl);
 
             while (!line.isEmpty()) {
                 httpHeader.append(appendNewLine(line));
@@ -48,21 +45,37 @@ public class RequestHandler implements Runnable {
             }
 
             DataOutputStream dos = new DataOutputStream(out);
+            readFile(dos, requestUrl);
+        } catch (IOException e) {
+            logger.error(e.getMessage());
+        }
+    }
 
+    private void readFile(DataOutputStream dos, String requestUrl) {
+        final String DEFAULT_PATH = "src/main/resources/static";
+        File file = new File(DEFAULT_PATH.concat(requestUrl));
+
+        try (FileInputStream fileIn = new FileInputStream(file)){
             byte[] body = new byte[(int) file.length()];
             int readLen = fileIn.read(body);
-
-            response200Header(dos, readLen);
+            String mimeType = getMimeType(file);
+            response200Header(dos, readLen, mimeType);
             responseBody(dos, body);
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
     }
 
-    private void response200Header(DataOutputStream dos, int lengthOfBodyContent) {
+    private String getMimeType(File file) {
+        String fileName = file.getName();
+        String extension = fileName.substring(fileName.lastIndexOf(".") + 1);
+        return MIMEType.getContentType(extension);
+    }
+
+    private void response200Header(DataOutputStream dos, int lengthOfBodyContent, String mimeType) {
         try {
             dos.writeBytes("HTTP/1.1 200 OK \r\n");
-            dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
+            dos.writeBytes("Content-Type: " + mimeType + ";charset=utf-8\r\n");
             dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
             dos.writeBytes("\r\n");
         } catch (IOException e) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -1,13 +1,15 @@
 package webserver;
 
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static utils.StringUtils.*;
 
 public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
@@ -24,8 +26,31 @@ public class RequestHandler implements Runnable {
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
+            BufferedReader br = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
+            StringBuilder httpHeader = new StringBuilder();
+
+            String line = br.readLine();
+            if (line == null) {
+                return;
+            }
+
+            String[] tokens = line.split(" ");
+            logger.debug("request Method : {}, request Url : {}", tokens[0], tokens[1]);
+
+            while (!line.isEmpty()) {
+                httpHeader.append(appendNewLine(line));
+                line = br.readLine();
+            }
+
             DataOutputStream dos = new DataOutputStream(out);
-            byte[] body = "<h1>Hello World</h1>".getBytes();
+
+            final String DEFAULT_PATH = "src/main/resources/static/";
+            final String INDEX_HTML = "index.html";
+
+            Path filePath = Path.of(DEFAULT_PATH.concat(INDEX_HTML));
+
+            byte[] body = Files.readAllBytes(filePath);
+
             response200Header(dos, body.length);
             responseBody(dos, body);
         } catch (IOException e) {
@@ -36,6 +61,17 @@ public class RequestHandler implements Runnable {
     private void response200Header(DataOutputStream dos, int lengthOfBodyContent) {
         try {
             dos.writeBytes("HTTP/1.1 200 OK \r\n");
+            dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
+            dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
+            dos.writeBytes("\r\n");
+        } catch (IOException e) {
+            logger.error(e.getMessage());
+        }
+    }
+
+    private void response404Header(DataOutputStream dos, int lengthOfBodyContent) {
+        try {
+            dos.writeBytes("HTTP/1.1 404 NOT FOUND \r\n");
             dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
             dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
             dos.writeBytes("\r\n");

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -2,6 +2,8 @@ package webserver;
 
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,7 +12,7 @@ public class WebServer {
     private static final Logger logger = LoggerFactory.getLogger(WebServer.class);
     private static final int DEFAULT_PORT = 8080;
 
-    public static void main(String args[]) throws Exception {
+    public static void main(String[] args) throws Exception {
         int port = 0;
         if (args == null || args.length == 0) {
             port = DEFAULT_PORT;
@@ -25,8 +27,8 @@ public class WebServer {
             // 클라이언트가 연결될때까지 대기한다.
             Socket connection;
             while ((connection = listenSocket.accept()) != null) {
-                Thread thread = new Thread(new RequestHandler(connection));
-                thread.start();
+                ExecutorService executorService = Executors.newCachedThreadPool();
+                executorService.execute(new RequestHandler(connection));
             }
         }
     }


### PR DESCRIPTION
### 학습 내용
[소켓, 입출력 스트림, 프로세스와 스레드](https://github.com/sharpie1330/be-was-neon/wiki/%EC%86%8C%EC%BC%93,-%EC%9E%85%EC%B6%9C%EB%A0%A5-%EC%8A%A4%ED%8A%B8%EB%A6%BC,-%ED%94%84%EB%A1%9C%EC%84%B8%EC%8A%A4%EC%99%80-%EC%8A%A4%EB%A0%88%EB%93%9C)
- New Client Connect! Connected IP : {}, Port : {} 로그 메시지에서 포트 번호가 매번 바뀌는 이유
  - 클라이언트 측에서 요청을 보낼 때 운영체제가 동적으로 포트를 할당해 준다. 요청을 보낸 해당 포트로 응답을 보내면 된다.
  - 서버 측에서는 8080포트로 지정해 주었기 때문에 해당 포트로 항상 listen 중. 이 어플리케이션을 구분하는 포트 번호가 8080이다.

### 구현 내용
- 요청의 첫 줄을 읽으면 GET과 같은 request method와 request url, HTTP/1.1과 같은 프로토콜 순서로 표시된다. 
- 따라서 해당 request line의 request url과 method를 파싱해 로거로 출력했다.
- request url에는 클라이언트가 GET을 요청하는 경로가 담겨있고, 해당 파일의 확장자에 따라 ContentType을 다르게 처리해 응답해주어야 한다.
- 우선 해당 경로의 파일을 찾아 바이트 배열로 읽고, 파일의 확장자로 MimeType을 결정한다. 이때 nio 라이브러리를 사용하지 않기 위해 FileInputStream 클래스를 사용해 구현했다.
- MimeType은 enum 클래스로 만들어서 파일의 확장자와 같은 이름의 enum 상수가 있으면 해당 상수의 mimeType값을 구할 수 있도록 했다.

## 고민 사항
1. ThreadPool 선택

concurrent 패키지로 변경하면서 newFixedThreadPool과 newCachedThreadPool중 무엇을 사용할지에 대한 고민을 했다.

스레드풀을 직접 생성하려면 ThreadPoolExecutor로 초기 수와 코어 수, 최대 수, 놀고 있는 시간과 단위, 작업 큐를 초기화해 생성할 수 있다.

fixed의 경우 파라미터 정수값을 최대값으로 스레드를 생성하고, 생성된 스레드를 제거하지 않는다.
반면 cached의 경우 스레드를 최대 정수형 변수 최대값 개수만큼 생성할 수 있고, 60초동안 스레드가 놀고 있으면 스레드를 제거한다.

이 프로그램에서는 로컬에서 작업하는 만큼 최소 유지 스레드 수인 코어 수를 따로 지정할 정도로 부하가 없을 것이라고 생각했고, 정수형 범위를 넘어갈 정로의 요청이 들어올 일도 없을 것이라 생각해 newCachedThreadPool로 스레드 풀을 생성했다.

2. Content-Type 설정

html파일을 읽는데 왜 css와 svg 파일 등이 같이 적용되서 조회지 않는지 의아했다. html 문서는 다른 리소스를 참조하는 링크나 경로를 포함하고 있는데, 웹 브라우저는 html을 가져온 후 해당 문서에서 참조된 외부 리소스를 다시 가져와 화면에 표시한다. request line을 로거를 통해 출력하면 GET 요청이 여러 개 온 것을 확인할 수 있다. 따라서 mimeType enum 클래스를 생성해 파일 확장자별로 contentType을 다르게 해 응답해 해결했다.

## 기타