### PR TITLE
[Daniel] step-2 GET으로 회원가입

### DIFF
--- a/src/main/java/utils/StringUtils.java
+++ b/src/main/java/utils/StringUtils.java
@@ -1,8 +1,21 @@
 package utils;
 
 public class StringUtils {
+    private static final String BASIC_FILE_PATH = "src/main/resources/static";
+    private static final String INDEX_FILE_NAME = "/index.html";
+
     public static String separatePath(String requestStartLine){ // request method에서 경로만 분리하기
         String[] splitStartLine = requestStartLine.split(" ");
         return splitStartLine[1];
     }
+
+    public static String makeCompletePath(String requestURL){
+        StringBuilder completePath = new StringBuilder(BASIC_FILE_PATH);
+        if(!requestURL.equals(INDEX_FILE_NAME)){
+            completePath.append(requestURL);
+        }
+        completePath.append(INDEX_FILE_NAME);
+        return completePath.toString();
+    }
+
 }

--- a/src/main/java/utils/StringUtils.java
+++ b/src/main/java/utils/StringUtils.java
@@ -1,5 +1,7 @@
 package utils;
 
+import webserver.RequestHandler;
+
 public class StringUtils {
     private static final String BASIC_FILE_PATH = "src/main/resources/static";
     private static final String INDEX_FILE_NAME = "/index.html";
@@ -11,7 +13,7 @@ public class StringUtils {
 
     public static String makeCompletePath(String requestURL){
         StringBuilder completePath = new StringBuilder(BASIC_FILE_PATH);
-        if(!requestURL.equals(INDEX_FILE_NAME)){
+        if(!requestURL.equals(INDEX_FILE_NAME) && !requestURL.contains(RequestHandler.REGISTER_ACTION)){
             completePath.append(requestURL);
         }
         completePath.append(INDEX_FILE_NAME);

--- a/src/main/java/webserver/RegisterRequestHandler.java
+++ b/src/main/java/webserver/RegisterRequestHandler.java
@@ -5,29 +5,33 @@ import model.User;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.util.HashMap;
 
 public class RegisterRequestHandler {
+    HashMap<String, String> registerInfo = new HashMap<String, String>(); //ex) <userID, daniel>
+
     RegisterRequestHandler(String startLine) {
-        storeDatabase(parseRegisterRequest(startLine));
+        parseRegisterInfo(removeUseless(startLine));
+        storeDatabase();
     }
-    private User parseRegisterRequest(String startLine) {
-        String[] splitLine = startLine.split("[=& ]");
-        String userId = "", password = "", name = "", email = "";
-        try {
-            // 디코딩하여 한글로 변환
-            userId = URLDecoder.decode(splitLine[2], "UTF-8");
-            password = URLDecoder.decode(splitLine[4], "UTF-8");
-            name = URLDecoder.decode(splitLine[6], "UTF-8");
-            email = URLDecoder.decode(splitLine[8], "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            e.printStackTrace();
+
+    private void parseRegisterInfo(String registerLine) {
+        for(String token : registerLine.split("[& ]")){
+            String[] splitInfo = token.split("="); // 이름과 값을 = 로 분리
+            try {
+                registerInfo.put(splitInfo[0], URLDecoder.decode(splitInfo[1], "UTF-8")); // 해쉬 맵에 정보 저장
+            } catch (UnsupportedEncodingException e) {
+                e.printStackTrace();
+            }
         }
-
-        return new User(userId, password, name, email);
     }
 
-    private void storeDatabase(User user){
-        Database.addUser(user);
+    private String removeUseless(String startLine){ // 사용자 입력 정보 부분만 반환
+        String[] splitStartLine = startLine.split("[? ]");
+        return splitStartLine[2];
     }
 
+    private void storeDatabase(){
+        Database.addUser(new User(registerInfo.get("userId"), registerInfo.get("password"), registerInfo.get("name"), registerInfo.get("email")));
+    }
 }

--- a/src/main/java/webserver/RegisterRequestHandler.java
+++ b/src/main/java/webserver/RegisterRequestHandler.java
@@ -1,0 +1,33 @@
+package webserver;
+
+import db.Database;
+import model.User;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+
+public class RegisterRequestHandler {
+    RegisterRequestHandler(String startLine) {
+        storeDatabase(parseRegisterRequest(startLine));
+    }
+    private User parseRegisterRequest(String startLine) {
+        String[] splitLine = startLine.split("[=& ]");
+        String userId = "", password = "", name = "", email = "";
+        try {
+            // 디코딩하여 한글로 변환
+            userId = URLDecoder.decode(splitLine[2], "UTF-8");
+            password = URLDecoder.decode(splitLine[4], "UTF-8");
+            name = URLDecoder.decode(splitLine[6], "UTF-8");
+            email = URLDecoder.decode(splitLine[8], "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+
+        return new User(userId, password, name, email);
+    }
+
+    private void storeDatabase(User user){
+        Database.addUser(user);
+    }
+
+}

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -2,11 +2,14 @@ package webserver;
 
 import java.io.*;
 import java.net.Socket;
+import java.net.URLDecoder;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import utils.StringUtils;
+import model.User;
+import db.Database;
 
 public class RequestHandler implements Runnable {
     private static final String REGISTER_ACTION = "/user/create";
@@ -29,9 +32,8 @@ public class RequestHandler implements Runnable {
             String requestLine = br.readLine();
             logger.debug("request method : {}", requestLine);
             if(checkRegisterInput(requestLine)){
-
+                Database.addUser(parseRegisterRequest(requestLine));
             }
-
 
             // 요청 받은 URL을 파싱하여 파일 경로를 결정한다.
             String requestURL = StringUtils.separatePath(requestLine);
@@ -97,7 +99,19 @@ public class RequestHandler implements Runnable {
         }
     }
 
-    private boolean checkRegisterInput(String requestLine){
-        return requestLine.contains(REGISTER_ACTION);
+    private boolean checkRegisterInput(String startLine){ // 회원가입에서 보낸 GET인지 확인
+        return startLine.contains(REGISTER_ACTION);
+    }
+
+    private User parseRegisterRequest(String startLine) throws UnsupportedEncodingException {
+        String[] splitLine = startLine.split("[=& ]");
+
+        // 디코딩하여 한글로 변환
+        String userId = URLDecoder.decode(splitLine[2], "UTF-8");
+        String password = URLDecoder.decode(splitLine[4], "UTF-8");
+        String name = URLDecoder.decode(splitLine[6], "UTF-8");
+        String email = URLDecoder.decode(splitLine[8], "UTF-8");
+
+        return new User(userId, password, name, email);
     }
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import utils.StringUtils;
 
 public class RequestHandler implements Runnable {
+    private static final String REGISTER_ACTION = "/user/create";
 
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
 
@@ -27,6 +28,10 @@ public class RequestHandler implements Runnable {
 
             String requestLine = br.readLine();
             logger.debug("request method : {}", requestLine);
+            if(checkRegisterInput(requestLine)){
+
+            }
+
 
             // 요청 받은 URL을 파싱하여 파일 경로를 결정한다.
             String requestURL = StringUtils.separatePath(requestLine);
@@ -90,5 +95,9 @@ public class RequestHandler implements Runnable {
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
+    }
+
+    private boolean checkRegisterInput(String requestLine){
+        return requestLine.contains(REGISTER_ACTION);
     }
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -2,17 +2,15 @@ package webserver;
 
 import java.io.*;
 import java.net.Socket;
-import java.net.URLDecoder;
+
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import utils.StringUtils;
-import model.User;
-import db.Database;
 
 public class RequestHandler implements Runnable {
-    private static final String REGISTER_ACTION = "/user/create";
+    public static final String REGISTER_ACTION = "/user/create";
 
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
 
@@ -32,7 +30,7 @@ public class RequestHandler implements Runnable {
             String requestLine = br.readLine();
             logger.debug("request method : {}", requestLine);
             if(checkRegisterInput(requestLine)){
-                Database.addUser(parseRegisterRequest(requestLine));
+                RegisterRequestHandler registerRH = new RegisterRequestHandler(requestLine);
             }
 
             // 요청 받은 URL을 파싱하여 파일 경로를 결정한다.
@@ -101,17 +99,5 @@ public class RequestHandler implements Runnable {
 
     private boolean checkRegisterInput(String startLine){ // 회원가입에서 보낸 GET인지 확인
         return startLine.contains(REGISTER_ACTION);
-    }
-
-    private User parseRegisterRequest(String startLine) throws UnsupportedEncodingException {
-        String[] splitLine = startLine.split("[=& ]");
-
-        // 디코딩하여 한글로 변환
-        String userId = URLDecoder.decode(splitLine[2], "UTF-8");
-        String password = URLDecoder.decode(splitLine[4], "UTF-8");
-        String name = URLDecoder.decode(splitLine[6], "UTF-8");
-        String email = URLDecoder.decode(splitLine[8], "UTF-8");
-
-        return new User(userId, password, name, email);
     }
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -9,7 +9,6 @@ import org.slf4j.LoggerFactory;
 import utils.StringUtils;
 
 public class RequestHandler implements Runnable {
-    private static final String FILE_PATH = "src/main/resources/static";
 
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
 
@@ -31,7 +30,7 @@ public class RequestHandler implements Runnable {
 
             // 요청 받은 URL을 파싱하여 파일 경로를 결정한다.
             String requestURL = StringUtils.separatePath(requestLine);
-            String filePath = FILE_PATH + requestURL;
+            String filePath = StringUtils.makeCompletePath(requestURL);
 
             requestLine = br.readLine();
             while(!requestLine.isEmpty()){ // 나머지 header 출력

--- a/src/main/resources/static/registration/index.html
+++ b/src/main/resources/static/registration/index.html
@@ -34,22 +34,32 @@
             />
           </div>
           <div class="textfield textfield_size_s">
-            <p class="title_textfield">닉네임</p>
+            <p class="title_textfield">비밀번호</p>
+            <input
+                    class="input_textfield"
+                    name = "password"
+                    type="password"
+                    placeholder="비밀번호를 입력해주세요"
+                    autocomplete="current-password"
+            />
+          </div>
+          <div class="textfield textfield_size_s">
+            <p class="title_textfield">이름</p>
             <input
               class="input_textfield"
-              name = "password"
-              placeholder="닉네임을 입력해주세요"
+              name = "name"
+              placeholder="이름을 입력해주세요"
               autocomplete="username"
             />
           </div>
           <div class="textfield textfield_size_s">
-            <p class="title_textfield">비밀번호</p>
+            <p class="title_textfield">이메일</p>
             <input
-              class="input_textfield"
-              name = "name"
-              type="password"
-              placeholder="비밀번호를 입력해주세요"
-              autocomplete="current-password"
+                    class="input_textfield"
+                    name = "email"
+                    type="email"
+                    placeholder="이메일을 입력해주세요"
+                    autocomplete="current-email"
             />
           </div>
           <button

--- a/src/main/resources/static/registration/index.html
+++ b/src/main/resources/static/registration/index.html
@@ -23,11 +23,12 @@
       </header>
       <div class="page">
         <h2 class="page-title">회원가입</h2>
-        <form class="form">
+        <form class="form" action="/user/create" method="GET">
           <div class="textfield textfield_size_s">
             <p class="title_textfield">아이디</p>
             <input
               class="input_textfield"
+              name = "userId"
               placeholder="아이디를 입력해주세요"
               autocomplete="username"
             />
@@ -36,6 +37,7 @@
             <p class="title_textfield">닉네임</p>
             <input
               class="input_textfield"
+              name = "password"
               placeholder="닉네임을 입력해주세요"
               autocomplete="username"
             />
@@ -44,6 +46,7 @@
             <p class="title_textfield">비밀번호</p>
             <input
               class="input_textfield"
+              name = "name"
               type="password"
               placeholder="비밀번호를 입력해주세요"
               autocomplete="current-password"
@@ -53,7 +56,7 @@
             id="registration-btn"
             class="btn btn_contained btn_size_m"
             style="margin-top: 24px"
-            type="button"
+            type="submit"
           >
             회원가입
           </button>

--- a/src/test/java/utils/StringUtilsTest.java
+++ b/src/test/java/utils/StringUtilsTest.java
@@ -13,7 +13,13 @@ public class StringUtilsTest {
         assertThat(requestURL).isEqualTo("/index.html");
     }
 
+    @Test
+    @DisplayName("request method의 경로가 /registration일 경우 회원가입 페이지의 경로를 반환해야 한다.")
+    void getRegisterPath() {
+        String requestLine = "GET /registration HTTP/1.1\n";
 
-
-
+        String requestURL = StringUtils.separatePath(requestLine);
+        String registerLocation = StringUtils.makeCompletePath(requestURL);
+        assertThat(registerLocation).isEqualTo("src/main/resources/static/registration/index.html");
+    }
 }

--- a/src/test/java/utils/StringUtilsTest.java
+++ b/src/test/java/utils/StringUtilsTest.java
@@ -3,7 +3,7 @@ package utils;
 import org.junit.jupiter.api.*;
 import static org.assertj.core.api.Assertions.*; // AssertJ
 
-public class StringUtilsTest {
+class StringUtilsTest {
     @Test
     @DisplayName("request method에서 파일 경로를 분리해야 한다.")
     void extractPath() {

--- a/src/test/java/webserver/RegisterRequestHandlerTest.java
+++ b/src/test/java/webserver/RegisterRequestHandlerTest.java
@@ -12,7 +12,7 @@ public class RegisterRequestHandlerTest {
 
     @Test
     @DisplayName("Request Header에서 Request Parameter 를 추출하여 User 클래스에 담아야 한다.")
-    void extractPath() {
+    void parseRegisterInfo() {
         String requestStartLine = "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1";
 
         RegisterRequestHandler registerRH = new RegisterRequestHandler(requestStartLine);

--- a/src/test/java/webserver/RegisterRequestHandlerTest.java
+++ b/src/test/java/webserver/RegisterRequestHandlerTest.java
@@ -8,7 +8,7 @@ import utils.StringUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class RegisterRequestHandlerTest {
+class RegisterRequestHandlerTest {
 
     @Test
     @DisplayName("Request Header에서 Request Parameter 를 추출하여 User 클래스에 담아야 한다.")

--- a/src/test/java/webserver/RegisterRequestHandlerTest.java
+++ b/src/test/java/webserver/RegisterRequestHandlerTest.java
@@ -1,0 +1,26 @@
+package webserver;
+
+import model.User;
+import db.Database;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import utils.StringUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RegisterRequestHandlerTest {
+
+    @Test
+    @DisplayName("Request Header에서 Request Parameter 를 추출하여 User 클래스에 담아야 한다.")
+    void extractPath() {
+        String requestStartLine = "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1";
+
+        RegisterRequestHandler registerRH = new RegisterRequestHandler(requestStartLine);
+        User user = Database.findUserById("javajigi");
+        assertThat(user.getUserId()).isEqualTo("javajigi");
+        assertThat(user.getPassword()).isEqualTo("password");
+        assertThat(user.getName()).isEqualTo("박재성");
+        assertThat(user.getEmail()).isEqualTo("javajigi@slipp.net");
+    }
+
+}


### PR DESCRIPTION
## 구현 내용
### 회원가입 페이지로 이동 기능 구현
- makeCompletePath 매소드를 통해 /register/index.html로 경로를 지정해 주었습니다.

### index.html의 form태그 수정
- form 태그 안의 버튼 타입을 submit으로 변경 하였습니다.
- email input 태그 추가 했습니다.

### 회원가입 페이지에서 사용자가 입력한 값을 파싱하는 기능 구현
- 회원가입 reqeust 정보를 처리하기 위해서 RegisterRequestHandler 클래스를 생성하였습니다.
- 정보의 이름을 key로, 값을 value로 HashMap에 저장했습니다.
- storeDatabase 매소드는 파싱한 정보로 User 객체를 생성해 Database에 추가합니다.

## 고민 사항
- GET은 서버의 리소스에서 데이터를 요청할 때, POST는 서버의 리소스를 새로 생성하거나 업데이트할 때 사용한다고 공부했습니다. 때문에 회원가입 정보를 서버에 보낼 때 POST 방식이 더 적합하지 않을까 라는 생각이 들었습니다. 하지만 상대적으로 전달할 데이터가 적고, POST 방식에서는 body를 새로 파싱해야 된다는 점에서 GET방식이 편리한 것 같습니다.

## 기타
