### PR TITLE
[yelly] step-3 다양한 컨텐츠 타입 지원

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,33 @@ sequenceDiagram
     WebServer->>RequestHandler: 3. Socket(connection) 전달
     activate RequestHandler
     RequestHandler->>RequestHandler: 4. HttpConverter --> `HttpRequest`, `HttpResponse` 생성
-    RequestHandler->>StaticMapper: 5. `HttpRequest`를 처리할 수 있는 `Processor` 전달 요청
-    StaticMapper-->>RequestHandler: 6. `Processor` 반환 (HttpRequest, HttpResponse 처리)
+    RequestHandler->>UriMapper: 5. `HttpRequest`를 처리할 수 있는 `Processor` 전달 요청
+    UriMapper-->>RequestHandler: 6. `Processor` 반환 (HttpRequest, HttpResponse 처리)
     RequestHandler->>RequestHandler: 7. `Processor` 로직 실행 (없으면 404 Not Found)
     RequestHandler-->>client: 8. `HttpResponse` 응답
     deactivate RequestHandler
     activate client
     client-->>client: 9. 화면 구성
     deactivate client
+```
+
+## 회원가입 흐름(GET 버전)
+```mermaid
+sequenceDiagram
+    actor client
+    client->>WebServer: 1. GET 요청: "/registration?id=yelly&password=qwerty"
+    WebServer->>RequestHandler: 2. Socket(connection) 전달
+    activate RequestHandler
+    RequestHandler->>RequestHandler: 3. UriMapper 통해 회원가입 처리할 Processor 찾음
+    RequestHandler->>Processor: 4. HttpRequest 처리 요청
+    activate Processor
+    Processor->>Processor: 5. User 생성
+    Processor->>Database: 6. User 등록 요청
+    deactivate Processor
+    RequestHandler-->>client: 7. HttpResponse 반환 (200 OK (추후 201 created로 변경))
+    deactivate RequestHandler
+    client->>WebServer: 8. `/registration` 리디렉션 (WebServer에 다시 GET 요청)
+    WebServer-->>client: 9. `/registration` 리디렉션 응답(RequestHandler 전달 생략)
 ```
 
 # 기능 구현 리스트

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ sequenceDiagram
 
 ## ResourceHandler
 - [x] 파일을 읽어 byte로 변환할 수 있다
+- [x] URI 경로에서 확장자만 추출할 수 있다
 
 ## StaticMapper
 - [x] 요청 URI에 해당하는 정적 파일을 매핑할 수 있다

--- a/src/main/java/http/HttpResponse.java
+++ b/src/main/java/http/HttpResponse.java
@@ -70,8 +70,9 @@ public class HttpResponse {
     }
 
     public HttpResponse setMessageBody(byte[] bytesMessageBody) {
-        writeString(CRLF + CRLF);
+        writeString(CRLF);
         writeBytes(bytesMessageBody);
+        writeString(CRLF);
         return this;
     }
 

--- a/src/main/java/utils/ResourceHandler.java
+++ b/src/main/java/utils/ResourceHandler.java
@@ -3,14 +3,23 @@ package utils;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ResourceHandler {
     private static final Logger logger = LoggerFactory.getLogger(ResourceHandler.class);
-    public static String RESOURCE_PATH = "./src/main/resources/static";
-    public static String BASE_NAME = "index";
-    public static String HTML_EXTENSION = ".html";
+    public static final String RESOURCE_PATH = "./src/main/resources/static";
+    public static final String INDEX_HTML = "index.html";
+    public static final Map<String, String> FILE_EXTENSION_MAP = Map.of(
+            ".html","text/html",
+            ".css", "text/css",
+            ".js", "application/javascript",
+            ".ico", "image/x-icon",
+            ".png", "image/png",
+            ".jpg", "image/jpeg",
+            ".svg", "image/svg+xml");
+
 
     public static byte[] read(String filePath) {
         File file = new File(filePath);
@@ -24,5 +33,12 @@ public class ResourceHandler {
         }
 
         return byteArray;
+    }
+
+    public static String getExtension(String uri) {
+        if (uri.contains(".")) {
+            return uri.substring(uri.lastIndexOf("."));
+        }
+        return uri;
     }
 }

--- a/src/main/java/web/MemberSave.java
+++ b/src/main/java/web/MemberSave.java
@@ -13,12 +13,12 @@ public class MemberSave extends HtmlProcessor {
             super.process(request, response);
             return;
         }
-            String id = request.getParameter("id");
-            String username = request.getParameter("username");
-            String email = request.getParameter("email");
-            String password = request.getParameter("password");
+        String id = request.getParameter("id");
+        String username = request.getParameter("username");
+        String email = request.getParameter("email");
+        String password = request.getParameter("password");
 
-            Database.addUser(new User(id, password, username, email));
-            super.process(request, response);
+        Database.addUser(new User(id, password, username, email));
+        super.process(request, response);
     }
 }

--- a/src/main/java/web/UriMapper.java
+++ b/src/main/java/web/UriMapper.java
@@ -1,5 +1,7 @@
 package web;
 
+import static utils.ResourceHandler.*;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -28,15 +30,17 @@ public class UriMapper {
 
     private static void setUriMap() {
         URI_MAP.put("/", new HtmlProcessor());
-        URI_MAP.put("/index.html", new HtmlProcessor());
         URI_MAP.put("/registration", new MemberSave());
     }
 
     public Optional<HttpProcessor> getProcessor(String uri) {
-        if (!URI_MAP.containsKey(uri)) {
-            logger.debug("[STATIC MAPPER] NOT FOUND: {}", uri);
-            return Optional.empty();
+        if (URI_MAP.containsKey(uri)) {
+            return Optional.of(URI_MAP.get(uri));
         }
-        return Optional.of(URI_MAP.get(uri));
+        if (FILE_EXTENSION_MAP.containsKey(getExtension(uri))) {
+            return Optional.of(URI_MAP.get("/"));
+        }
+        logger.debug("[STATIC MAPPER] NOT FOUND: {}", uri);
+        return Optional.empty();
     }
 }

--- a/src/test/java/utils/ResourceHandlerTest.java
+++ b/src/test/java/utils/ResourceHandlerTest.java
@@ -2,6 +2,7 @@ package utils;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -31,5 +32,26 @@ class ResourceHandlerTest {
 
         // then
         assertThat(bytes.length).isEqualTo(0);
+    }
+
+    @DisplayName("확장자 .html, .css, .svg, .js를 포함하는 경로에서 확장자만 추출할 수 있다")
+    @Test
+    void getExtension() {
+        // given
+        List<String> uriList = List.of("/index.html", "/min.css", "/img/test.svg", "/main.js");
+
+        // when
+        List<String> extensions = uriList.stream()
+                .map(ResourceHandler::getExtension)
+                .toList();
+
+        // then
+        assertThat(extensions.size()).isEqualTo(4);
+        assertThat(extensions).contains(
+                ".html",
+                ".css",
+                ".svg",
+                ".js"
+        );
     }
 }


### PR DESCRIPTION
## 구현 내용
- 다양한 컨텐츠 타입(png, svg, ico, js, css)에 대해 하나의 클래스가 지원하도록 구현했습니다.
  - 컨텐츠 타입에 따라 알맞은 Content-Type을 매핑해서 처리하도록 구현했습니다.

## 고민 사항
- 쿼리 파라미터에 동일한 이름의 파라미터 이름이 들어왔을 때도 꺼낼 수 있어야 한다고 생각했습니다.
  - 중복 Key를 지원하는 Map을 만드는 것이 오버 엔지니어링인 것 같아 구현하지 않고, 일단 중복 Key에 대해 덮어쓰는 방식으로 구현했습니다.
  - 이 부분은 현재 스텝에서 사용하지 않는 Cookie에 대해서도 적용되는 부분이라, 다음 스텝에서 Cookie를 사용한다면 Cookie와 Parameter 부분을 별도의 클래스로 분리하는 것을 고려하고 있습니다.

- HttpResponseBuilder로 response body 이전에 response header를 먼저 설정하도록 강제하는 것이 괜찮은 선택인지 고민이 됩니다.
```java
    @Override
    public void process(HttpRequest request, HttpResponse response) {
        byte[] resource = getBytes(request);

        responseHeader200(response, getContentType(request));
        responseMessage(response, resource);

        response.flush();
    }

    private void responseHeader200(HttpResponse response, String contentType) {
        response.setHttpVersion("HTTP/1.1")
                .setStatusCode(HttpStatus.STATUS_OK)
                .setContentType(contentType)
                .setCharset("utf-8");
    }

    private void responseMessage(HttpResponse response, byte[] resource) {
        response.setContentLength(resource.length)
                .setMessageBody(resource);
    }
```
  response를 만들 때 message를 만들기 전에 header를 작성해야 합니다.  
  위의 경우 정해진 순서대로 `responseHeader200`, `responseMessage`가 호출되도록 작성했습니다.  
  코드를 작성한 제 자신 뿐만 아니라, 다른 개발자들이 이 코드를 보고 `responseMessage`를 먼저 호출하는 실수를 방지하게끔 장치를 만드는 것을 고민하고 있습니다.  
  미션이 진행되면서 Http 요청 처리 로직이 복잡해졌을 때 작성하고자 합니다.

## 구현 화면
<img width="460" alt="was1-step3-1" src="https://github.com/codesquad-members-2024/be-was-neon/assets/87357932/6d7c15ee-d32d-4bfb-98ab-395df41d08dc">

