### PR TITLE
 [코리] step-2 GET으로 회원가입, step-3 다양한 컨텐츠 타입 지원

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,10 @@
 - HTTP Request 내용 출력
 - 파일 형식에 따라 HTTP Response Header 의 content-type을 변경
 - 요청 타켓이 디렉토리면 해당 디렉토리의 `index.html` 파일을 반환하도록 구현
+- RequestHandler의 run 메서드의 코드를 HttpRequest, HttpResponse 클래스로 분할
+
+## 요청 타겟 별 기능
+- `/` : `index.html` 을 반환
+- `/login` : `login/index.html` 반환
+- `/registration` : `registration/index.html`
+- `/user/create` : 쿼리 파라미터의 값으로 User 객체를 만들어 저장

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@
   - 상태 줄은 프로토콜 버전, 상태 코드, 상태 텍스트가 존재한다. (`HTTP/1.1 404 Not Found.`)
   - HTTP 헤더가 존재한다.
   - 빈 줄 이후 본문이 위치한다.
+- HTTP Status
+  - 요청이 성공하면 `200 OK`
+  - 리다이렉션
+    - 리다이렉션하면 브라우저 URI에 쿼리파라미터가 남지 않게할 수 있다. 
+    - `301 Moved Permanently`는 요청 메서드가 GET이 되고, 요청 메시지 바디가 제거될 수 있음
+    - `308 Permanent Redirect`는 요청 메서드와 바디가 유지
 
 ## 구현 내용
 - Thread 대신 ExecutorService 를 사용하도록 리팩토링
@@ -19,9 +25,13 @@
 - 파일 형식에 따라 HTTP Response Header 의 content-type을 변경
 - 요청 타켓이 디렉토리면 해당 디렉토리의 `index.html` 파일을 반환하도록 구현
 - RequestHandler의 run 메서드의 코드를 HttpRequest, HttpResponse 클래스로 분할
+- 회원 가입 기능 구현
+  - 쿼리 파라미터를 파싱해 `Map`으로 저장하는 로직 추가
+  - 유저 정보가 들어있는 `Map` 객체를 받아 `User` 객체를 반환하는 정적 팩토리 메서드 구현  
+  - 회원 가입 시 로그인 페이지로 리다이렉션
 
 ## 요청 타겟 별 기능
 - `/` : `index.html` 을 반환
 - `/login` : `login/index.html` 반환
 - `/registration` : `registration/index.html`
-- `/user/create` : 쿼리 파라미터의 값으로 User 객체를 만들어 저장
+- `/create` : 쿼리 파라미터의 값으로 User 객체를 만들어 저장 후 로그인 페이지로 리다이렉트

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
 
     implementation 'ch.qos.logback:logback-classic:1.2.3'

--- a/src/main/java/model/User.java
+++ b/src/main/java/model/User.java
@@ -1,5 +1,7 @@
 package model;
 
+import java.util.Map;
+
 public class User {
     private String userId;
     private String password;
@@ -11,6 +13,10 @@ public class User {
         this.password = password;
         this.name = name;
         this.email = email;
+    }
+
+    public static User from(Map<String, String> user) {
+        return new User(user.get("userId"), user.get("password"), user.get("name"), user.get("email"));
     }
 
     public String getUserId() {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -7,15 +7,18 @@ import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.net.Socket;
+import java.util.List;
 
 public class RequestHandler implements Runnable {
 
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
 
     private final Socket connection;
+    private final RequestMapper requestMapper;
 
     public RequestHandler(Socket connectionSocket) {
         this.connection = connectionSocket;
+        requestMapper = new RequestMapper();
     }
 
     public void run() {
@@ -24,21 +27,35 @@ public class RequestHandler implements Runnable {
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
             HttpRequest httpRequest = HttpRequest.from(in);
-            httpRequest.read();
-
+            httpRequest.log();
             String requestTarget = httpRequest.getRequestTarget();
 
-            HttpResponse httpResponse = HttpResponse.from(out, requestTarget);
-            httpResponse.send();
-
+            HttpResponse httpResponse = requestMapper.getHttpResponse(requestTarget);
+            send(out, httpResponse);
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
     }
 
+    private void send(OutputStream out, HttpResponse httpResponse) {
+        DataOutputStream dos = new DataOutputStream(out);
+        try {
+            writeHeader(httpResponse.getHeader(), dos);
+            writeBody(httpResponse.getBody(), dos);
+            dos.flush();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
+    private void writeBody(byte[] body, DataOutputStream dos) throws IOException {
+        dos.write(body, 0, body.length);
+    }
 
-
-
+    private static void writeHeader(List<String> httpResponse, DataOutputStream dos) throws IOException {
+        for (String line : httpResponse) {
+            dos.writeBytes(line);
+        }
+    }
 
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -35,5 +35,5 @@ public class RequestHandler implements Runnable {
             logger.error(e.getMessage());
         }
     }
-    
+
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -28,9 +28,8 @@ public class RequestHandler implements Runnable {
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
             HttpRequest httpRequest = HttpRequest.from(in);
             httpRequest.log();
-            String requestTarget = httpRequest.getRequestTarget();
 
-            HttpResponse httpResponse = requestMapper.getHttpResponse(requestTarget);
+            HttpResponse httpResponse = requestMapper.service(httpRequest);
             send(out, httpResponse);
         } catch (IOException e) {
             logger.error(e.getMessage());
@@ -52,7 +51,7 @@ public class RequestHandler implements Runnable {
         dos.write(body, 0, body.length);
     }
 
-    private static void writeHeader(List<String> httpResponse, DataOutputStream dos) throws IOException {
+    private void writeHeader(List<String> httpResponse, DataOutputStream dos) throws IOException {
         for (String line : httpResponse) {
             dos.writeBytes(line);
         }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -30,31 +30,10 @@ public class RequestHandler implements Runnable {
             httpRequest.log();
 
             HttpResponse httpResponse = requestMapper.service(httpRequest);
-            send(out, httpResponse);
+            httpResponse.send(out);
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
     }
-
-    private void send(OutputStream out, HttpResponse httpResponse) {
-        DataOutputStream dos = new DataOutputStream(out);
-        try {
-            writeHeader(httpResponse.getHeader(), dos);
-            writeBody(httpResponse.getBody(), dos);
-            dos.flush();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private void writeBody(byte[] body, DataOutputStream dos) throws IOException {
-        dos.write(body, 0, body.length);
-    }
-
-    private void writeHeader(List<String> httpResponse, DataOutputStream dos) throws IOException {
-        for (String line : httpResponse) {
-            dos.writeBytes(line);
-        }
-    }
-
+    
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -1,13 +1,14 @@
 package webserver;
 
-import webserver.httpMessage.HttpRequest;
-import webserver.httpMessage.HttpResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import webserver.httpMessage.HttpRequest;
+import webserver.httpMessage.HttpResponse;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.Socket;
-import java.util.List;
 
 public class RequestHandler implements Runnable {
 

--- a/src/main/java/webserver/RequestMapper.java
+++ b/src/main/java/webserver/RequestMapper.java
@@ -1,41 +1,62 @@
 package webserver;
 
+import db.Database;
+import model.User;
+import webserver.httpMessage.HttpRequest;
 import webserver.httpMessage.HttpResponse;
+import webserver.utils.Parser;
 
 import java.io.File;
+import java.io.UnsupportedEncodingException;
 import java.util.Map;
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 public class RequestMapper {
 
     private static final String STATIC_PATH = "src/main/resources/static";
     private static final String INDEX_HTML = "/index.html";
 
-    private final Map<String, Supplier<HttpResponse>> map = Map.ofEntries(
+    private final Map<String, Function<HttpRequest, HttpResponse>> map = Map.ofEntries(
             Map.entry("/", this::home),
             Map.entry("/registration", this::register),
-            Map.entry("/login", this::login)
+            Map.entry("/login", this::login),
+            Map.entry("/create", this::createUser)
     );
 
-    public HttpResponse getHttpResponse(String requestTarget) {
-        if (requestTarget.contains(".")) {
-            return HttpResponse.from(new File(STATIC_PATH + requestTarget));
+    public HttpResponse service(HttpRequest request) {
+        String uri = request.getUri();
+        System.out.println(uri);
+        if (map.containsKey(uri)) {
+            return map.get(uri).apply(request);
         }
-        return map.get(requestTarget).get();
+        return HttpResponse.from(new File(STATIC_PATH + uri));
     }
 
-    private HttpResponse home() {
+    private HttpResponse home(HttpRequest request) {
         File file = new File(STATIC_PATH + INDEX_HTML);
         return HttpResponse.from(file);
     }
 
-    private HttpResponse register() {
+    private HttpResponse register(HttpRequest request) {
         File file = new File(STATIC_PATH + "/registration" + INDEX_HTML);
         return HttpResponse.from(file);
     }
 
-    private HttpResponse login() {
+    private HttpResponse login(HttpRequest request) {
         File file = new File(STATIC_PATH + "/login" + INDEX_HTML);
         return HttpResponse.from(file);
+    }
+
+    private HttpResponse createUser(HttpRequest request) {
+        String queryParams = request.getQueryParams();
+        System.out.println(queryParams);
+        try {
+            Map<String, String> userForm = Parser.splitQuery(queryParams);
+            Database.addUser(User.from(userForm));
+            File file = new File(STATIC_PATH + "/login" + INDEX_HTML);
+            return HttpResponse.from(file);
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/main/java/webserver/RequestMapper.java
+++ b/src/main/java/webserver/RequestMapper.java
@@ -25,7 +25,6 @@ public class RequestMapper {
 
     public HttpResponse service(HttpRequest request) {
         String uri = request.getUri();
-        System.out.println(uri);
         if (map.containsKey(uri)) {
             return map.get(uri).apply(request);
         }
@@ -49,7 +48,6 @@ public class RequestMapper {
 
     private HttpResponse createUser(HttpRequest request) {
         String queryParams = request.getQueryParams();
-        System.out.println(queryParams);
         try {
             Map<String, String> userForm = Parser.splitQuery(queryParams);
             Database.addUser(User.from(userForm));

--- a/src/main/java/webserver/RequestMapper.java
+++ b/src/main/java/webserver/RequestMapper.java
@@ -15,6 +15,8 @@ public class RequestMapper {
 
     private static final String STATIC_PATH = "src/main/resources/static";
     private static final String INDEX_HTML = "/index.html";
+    public static final String REGISTRATION = "/registration";
+    public static final String LOGIN = "/login";
 
     private final Map<String, Function<HttpRequest, HttpResponse>> map = Map.ofEntries(
             Map.entry("/", this::home),
@@ -37,12 +39,12 @@ public class RequestMapper {
     }
 
     private HttpResponse register(HttpRequest request) {
-        File file = new File(STATIC_PATH + "/registration" + INDEX_HTML);
+        File file = new File(STATIC_PATH + REGISTRATION + INDEX_HTML);
         return HttpResponse.from(file);
     }
 
     private HttpResponse login(HttpRequest request) {
-        File file = new File(STATIC_PATH + "/login" + INDEX_HTML);
+        File file = new File(STATIC_PATH + LOGIN + INDEX_HTML);
         return HttpResponse.from(file);
     }
 
@@ -51,7 +53,7 @@ public class RequestMapper {
         try {
             Map<String, String> userForm = Parser.splitQuery(queryParams);
             Database.addUser(User.from(userForm));
-            File file = new File(STATIC_PATH + "/login" + INDEX_HTML);
+            File file = new File(STATIC_PATH + LOGIN + INDEX_HTML);
             return HttpResponse.from(file);
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);

--- a/src/main/java/webserver/RequestMapper.java
+++ b/src/main/java/webserver/RequestMapper.java
@@ -1,0 +1,41 @@
+package webserver;
+
+import webserver.httpMessage.HttpResponse;
+
+import java.io.File;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class RequestMapper {
+
+    private static final String STATIC_PATH = "src/main/resources/static";
+    private static final String INDEX_HTML = "/index.html";
+
+    private final Map<String, Supplier<HttpResponse>> map = Map.ofEntries(
+            Map.entry("/", this::home),
+            Map.entry("/registration", this::register),
+            Map.entry("/login", this::login)
+    );
+
+    public HttpResponse getHttpResponse(String requestTarget) {
+        if (requestTarget.contains(".")) {
+            return HttpResponse.from(new File(STATIC_PATH + requestTarget));
+        }
+        return map.get(requestTarget).get();
+    }
+
+    private HttpResponse home() {
+        File file = new File(STATIC_PATH + INDEX_HTML);
+        return HttpResponse.from(file);
+    }
+
+    private HttpResponse register() {
+        File file = new File(STATIC_PATH + "/registration" + INDEX_HTML);
+        return HttpResponse.from(file);
+    }
+
+    private HttpResponse login() {
+        File file = new File(STATIC_PATH + "/login" + INDEX_HTML);
+        return HttpResponse.from(file);
+    }
+}

--- a/src/main/java/webserver/RequestMapper.java
+++ b/src/main/java/webserver/RequestMapper.java
@@ -53,8 +53,7 @@ public class RequestMapper {
         try {
             Map<String, String> userForm = Parser.splitQuery(queryParams);
             Database.addUser(User.from(userForm));
-            File file = new File(STATIC_PATH + LOGIN + INDEX_HTML);
-            return HttpResponse.from(file);
+            return HttpResponse.redirect(LOGIN);
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/webserver/TypeMapper.java
+++ b/src/main/java/webserver/TypeMapper.java
@@ -1,0 +1,27 @@
+package webserver;
+
+import java.io.File;
+import java.util.Map;
+
+public class TypeMapper {
+    private final static Map<String, String> map = Map.ofEntries(
+            Map.entry("html", "text/html"),
+            Map.entry("css", "text/css"),
+            Map.entry("svg", "image/svg+xml"),
+            Map.entry("ico", "image/x-icon")
+    );
+
+    public static String getContentType(File file) {
+        String extension = getExtension(file);
+        if (map.containsKey(extension)) {
+            return map.get(extension);
+        }
+        throw new IllegalArgumentException("존재하지 않는 타입입니다.");
+    }
+
+    private static String getExtension(File file) {
+        String fileName = file.getName();
+        String[] split = fileName.split("\\.");
+        return split[split.length - 1];
+    }
+}

--- a/src/main/java/webserver/httpMessage/HttpRequest.java
+++ b/src/main/java/webserver/httpMessage/HttpRequest.java
@@ -10,18 +10,24 @@ import java.util.List;
 public class HttpRequest {
 
     private static final Logger logger = LoggerFactory.getLogger(HttpRequest.class);
+    public static final String NO_QUERY_PARAMS = "";
+    public static final String EMPTY_HTTP_REQUEST_ERROR = "빈 HTTP 요청입니다.";
+    public static final String BLANK = " ";
+    public static final String REQUEST_TARGET_DELIMETER = "?";
     private final List<String> httpRequest;
     private final String startLine;
+    private final String requestTarget;
 
     public HttpRequest(List<String> httpRequest) {
         validate(httpRequest);
         this.httpRequest = httpRequest;
         this.startLine = httpRequest.get(0);
+        this.requestTarget = getRequestTarget();
     }
 
     private void validate(List<String> httpRequest) {
         if (httpRequest.isEmpty()) {
-            throw new IllegalArgumentException("빈 HTTP 요청입니다.");
+            throw new IllegalArgumentException(EMPTY_HTTP_REQUEST_ERROR);
         }
     }
 
@@ -43,9 +49,24 @@ public class HttpRequest {
         }
     }
 
-    public String getRequestTarget() {
-        String[] split = startLine.split(" ");
-        return split[1];
+    public String getUri() {
+        if (requestTarget.contains(REQUEST_TARGET_DELIMETER)) {
+            String[] split = requestTarget.split("\\?");
+            return split[0];
+        }
+        return requestTarget;
+    }
 
+    public String getQueryParams() {
+        if (requestTarget.contains(REQUEST_TARGET_DELIMETER)) {
+            String[] split = requestTarget.split("\\?");
+            return split[1];
+        }
+        return NO_QUERY_PARAMS;
+    }
+
+    private String getRequestTarget() {
+        String[] split = startLine.split(BLANK);
+        return split[1];
     }
 }

--- a/src/main/java/webserver/httpMessage/HttpRequest.java
+++ b/src/main/java/webserver/httpMessage/HttpRequest.java
@@ -14,6 +14,7 @@ public class HttpRequest {
     public static final String EMPTY_HTTP_REQUEST_ERROR = "빈 HTTP 요청입니다.";
     public static final String BLANK = " ";
     public static final String REQUEST_TARGET_DELIMITER = "?";
+
     private final List<String> httpRequest;
     private final String startLine;
     private final String requestTarget;

--- a/src/main/java/webserver/httpMessage/HttpRequest.java
+++ b/src/main/java/webserver/httpMessage/HttpRequest.java
@@ -13,7 +13,7 @@ public class HttpRequest {
     public static final String NO_QUERY_PARAMS = "";
     public static final String EMPTY_HTTP_REQUEST_ERROR = "빈 HTTP 요청입니다.";
     public static final String BLANK = " ";
-    public static final String REQUEST_TARGET_DELIMETER = "?";
+    public static final String REQUEST_TARGET_DELIMITER = "?";
     private final List<String> httpRequest;
     private final String startLine;
     private final String requestTarget;
@@ -50,7 +50,7 @@ public class HttpRequest {
     }
 
     public String getUri() {
-        if (requestTarget.contains(REQUEST_TARGET_DELIMETER)) {
+        if (requestTarget.contains(REQUEST_TARGET_DELIMITER)) {
             String[] split = requestTarget.split("\\?");
             return split[0];
         }
@@ -58,7 +58,7 @@ public class HttpRequest {
     }
 
     public String getQueryParams() {
-        if (requestTarget.contains(REQUEST_TARGET_DELIMETER)) {
+        if (requestTarget.contains(REQUEST_TARGET_DELIMITER)) {
             String[] split = requestTarget.split("\\?");
             return split[1];
         }

--- a/src/main/java/webserver/httpMessage/HttpRequest.java
+++ b/src/main/java/webserver/httpMessage/HttpRequest.java
@@ -1,0 +1,51 @@
+package webserver.httpMessage;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class HttpRequest {
+
+    private static final Logger logger = LoggerFactory.getLogger(HttpRequest.class);
+    private final List<String> httpRequest;
+    private final String startLine;
+
+    public HttpRequest(List<String> httpRequest) {
+        validate(httpRequest);
+        this.httpRequest = httpRequest;
+        this.startLine = httpRequest.get(0);
+    }
+
+    private void validate(List<String> httpRequest) {
+        if (httpRequest.isEmpty()) {
+            throw new IllegalArgumentException("빈 HTTP 요청입니다.");
+        }
+    }
+
+    public static HttpRequest from(InputStream in) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(in));
+        List<String> httpRequest = new ArrayList<>();
+
+        String line;
+        while (!(line = br.readLine()).isEmpty()) {
+            httpRequest.add(line);
+        }
+
+        return new HttpRequest(httpRequest);
+    }
+
+    public void read() {
+        for (String line : httpRequest) {
+            logger.debug("line = " + line);
+        }
+    }
+
+    public String getRequestTarget() {
+        String[] split = startLine.split(" ");
+        return split[1];
+
+    }
+}

--- a/src/main/java/webserver/httpMessage/HttpRequest.java
+++ b/src/main/java/webserver/httpMessage/HttpRequest.java
@@ -37,9 +37,9 @@ public class HttpRequest {
         return new HttpRequest(httpRequest);
     }
 
-    public void read() {
+    public void log() {
         for (String line : httpRequest) {
-            logger.debug("line = " + line);
+            logger.debug("request = " + line);
         }
     }
 

--- a/src/main/java/webserver/httpMessage/HttpResponse.java
+++ b/src/main/java/webserver/httpMessage/HttpResponse.java
@@ -56,7 +56,7 @@ public class HttpResponse {
     private static List<String> getHeader(String contentType, int bodyLength) {
         List<String> header = new ArrayList<>();
 
-        header.add("HTTP/1.1 200 OK \r\n");
+        header.add(HttpStatus.OK.getStatus_message());
         header.add("Content-Type: " + contentType + ";charset=utf-8\r\n");
         header.add("Content-Length: " + bodyLength + "\r\n");
         header.add("\r\n");
@@ -67,7 +67,7 @@ public class HttpResponse {
     private static List<String> getRedirectHeader(String location) {
         List<String> header = new ArrayList<>();
 
-        header.add("HTTP/1.1 308 Permanent Redirect \r\n");
+        header.add(HttpStatus.PERMANENT_REDIRECT.getStatus_message());
         header.add("Location: " + location);
         header.add("\r\n");
 

--- a/src/main/java/webserver/httpMessage/HttpResponse.java
+++ b/src/main/java/webserver/httpMessage/HttpResponse.java
@@ -2,95 +2,54 @@ package webserver.httpMessage;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import webserver.TypeMapper;
 
 import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
 
 public class HttpResponse {
 
     private static final Logger logger = LoggerFactory.getLogger(HttpResponse.class);
-    private static final String STATIC_PATH = "src/main/resources/static";
-    private static final String INDEX_HTML = "/index.html";
 
-    private final DataOutputStream dos;
-    private final String filePath;
+    private final List<String> header;
+    private final byte[] body;
 
-    private HttpResponse(DataOutputStream dos, String requestTarget) {
-        this.dos = dos;
-        filePath = getFilePath(requestTarget);
+    private HttpResponse(File file) {
+        header = getHeader(TypeMapper.getContentType(file), (int) file.length());
+        body = readFile(file);
     }
 
-    public static HttpResponse from(OutputStream out, String requestTarget) {
-        DataOutputStream dos = new DataOutputStream(out);
-        return new HttpResponse(dos, requestTarget);
+    public static HttpResponse from(File file) {
+        return new HttpResponse(file);
     }
 
-    private byte[] getBody(String filePath) throws IOException {
-        File file = new File(filePath);
+    private byte[] readFile(File file) {
         byte[] body = new byte[(int) file.length()];
         try (FileInputStream fis = new FileInputStream(file)) {
             fis.read(body);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
         return body;
     }
 
-    private String getFilePath(String requestTarget) {
-        if (isDirectory(requestTarget)) {
-            return STATIC_PATH + requestTarget + INDEX_HTML;
-        } else {
-            return STATIC_PATH + requestTarget;
-        }
+    public List<String> getHeader() {
+        return header;
     }
 
-    private static boolean isDirectory(String requestTarget) {
-        return !requestTarget.contains(".");
+    public byte[] getBody() {
+        return body;
     }
 
-    public void send() throws IOException {
-        byte[] body = getBody(filePath);
+    private List<String> getHeader(String contentType, int bodyLength) {
+        List<String> header = new ArrayList<>();
 
-        response200Header(body.length);
-        responseBody(body);
-    }
+        header.add("HTTP/1.1 200 OK \r\n");
+        header.add("Content-Type: " + contentType + ";charset=utf-8\r\n");
+        header.add("Content-Length: " + bodyLength + "\r\n");
+        header.add("\r\n");
 
-    private String getFileName(String filePath) {
-        String[] splitFilePath = filePath.split("/");
-        return splitFilePath[splitFilePath.length - 1];
-    }
-
-    private void response200Header(int lengthOfBodyContent) {
-        try {
-            dos.writeBytes("HTTP/1.1 200 OK \r\n");
-            dos.writeBytes("Content-Type: " + getContentType() + ";charset=utf-8\r\n");
-            dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
-            dos.writeBytes("\r\n");
-        } catch (IOException e) {
-            logger.error(e.getMessage());
-        }
-    }
-
-    private void responseBody(byte[] body) {
-        try {
-            dos.write(body, 0, body.length);
-            dos.flush();
-        } catch (IOException e) {
-            logger.error(e.getMessage());
-        }
-    }
-
-    private String getContentType() {
-        String fileName = getFileName(filePath);
-        String extension = getExtension(fileName);
-
-        return switch (extension) {
-            case "html", "css" -> "text/" + extension;
-            case "svg" -> "image/svg+xml";
-            case "ico" -> "image/x-icon";
-            default -> throw new IllegalArgumentException("");
-        };
-    }
-
-    private static String getExtension(String fileName) {
-        String[] split = fileName.split("\\.");
-        return split[split.length - 1];
+        return header;
     }
 }

--- a/src/main/java/webserver/httpMessage/HttpResponse.java
+++ b/src/main/java/webserver/httpMessage/HttpResponse.java
@@ -1,0 +1,96 @@
+package webserver.httpMessage;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+
+public class HttpResponse {
+
+    private static final Logger logger = LoggerFactory.getLogger(HttpResponse.class);
+    private static final String STATIC_PATH = "src/main/resources/static";
+    private static final String INDEX_HTML = "/index.html";
+
+    private final DataOutputStream dos;
+    private final String filePath;
+
+    private HttpResponse(DataOutputStream dos, String requestTarget) {
+        this.dos = dos;
+        filePath = getFilePath(requestTarget);
+    }
+
+    public static HttpResponse from(OutputStream out, String requestTarget) {
+        DataOutputStream dos = new DataOutputStream(out);
+        return new HttpResponse(dos, requestTarget);
+    }
+
+    private byte[] getBody(String filePath) throws IOException {
+        File file = new File(filePath);
+        byte[] body = new byte[(int) file.length()];
+        try (FileInputStream fis = new FileInputStream(file)) {
+            fis.read(body);
+        }
+        return body;
+    }
+
+    private String getFilePath(String requestTarget) {
+        if (isDirectory(requestTarget)) {
+            return STATIC_PATH + requestTarget + INDEX_HTML;
+        } else {
+            return STATIC_PATH + requestTarget;
+        }
+    }
+
+    private static boolean isDirectory(String requestTarget) {
+        return !requestTarget.contains(".");
+    }
+
+    public void send() throws IOException {
+        byte[] body = getBody(filePath);
+
+        response200Header(body.length);
+        responseBody(body);
+    }
+
+    private String getFileName(String filePath) {
+        String[] splitFilePath = filePath.split("/");
+        return splitFilePath[splitFilePath.length - 1];
+    }
+
+    private void response200Header(int lengthOfBodyContent) {
+        try {
+            dos.writeBytes("HTTP/1.1 200 OK \r\n");
+            dos.writeBytes("Content-Type: " + getContentType() + ";charset=utf-8\r\n");
+            dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
+            dos.writeBytes("\r\n");
+        } catch (IOException e) {
+            logger.error(e.getMessage());
+        }
+    }
+
+    private void responseBody(byte[] body) {
+        try {
+            dos.write(body, 0, body.length);
+            dos.flush();
+        } catch (IOException e) {
+            logger.error(e.getMessage());
+        }
+    }
+
+    private String getContentType() {
+        String fileName = getFileName(filePath);
+        String extension = getExtension(fileName);
+
+        return switch (extension) {
+            case "html", "css" -> "text/" + extension;
+            case "svg" -> "image/svg+xml";
+            case "ico" -> "image/x-icon";
+            default -> throw new IllegalArgumentException("");
+        };
+    }
+
+    private static String getExtension(String fileName) {
+        String[] split = fileName.split("\\.");
+        return split[split.length - 1];
+    }
+}

--- a/src/main/java/webserver/httpMessage/HttpResponse.java
+++ b/src/main/java/webserver/httpMessage/HttpResponse.java
@@ -2,7 +2,7 @@ package webserver.httpMessage;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import webserver.TypeMapper;
+import webserver.utils.TypeMapper;
 
 import java.io.*;
 import java.util.ArrayList;

--- a/src/main/java/webserver/httpMessage/HttpResponse.java
+++ b/src/main/java/webserver/httpMessage/HttpResponse.java
@@ -52,4 +52,25 @@ public class HttpResponse {
 
         return header;
     }
+
+    public void send(OutputStream out) {
+        DataOutputStream dos = new DataOutputStream(out);
+        try {
+            writeHeader(getHeader(), dos);
+            writeBody(getBody(), dos);
+            dos.flush();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void writeBody(byte[] body, DataOutputStream dos) throws IOException {
+        dos.write(body, 0, body.length);
+    }
+
+    private void writeHeader(List<String> httpResponse, DataOutputStream dos) throws IOException {
+        for (String line : httpResponse) {
+            dos.writeBytes(line);
+        }
+    }
 }

--- a/src/main/java/webserver/httpMessage/HttpStatus.java
+++ b/src/main/java/webserver/httpMessage/HttpStatus.java
@@ -1,0 +1,16 @@
+package webserver.httpMessage;
+
+public enum HttpStatus {
+    OK("HTTP/1.1 200 OK \r\n"),
+    PERMANENT_REDIRECT("HTTP/1.1 308 Permanent Redirect \r\n");
+
+    private final String status_message;
+
+    HttpStatus(String status_message) {
+        this.status_message = status_message;
+    }
+
+    public String getStatus_message() {
+        return status_message;
+    }
+}

--- a/src/main/java/webserver/utils/Parser.java
+++ b/src/main/java/webserver/utils/Parser.java
@@ -2,22 +2,21 @@ package webserver.utils;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
 public class Parser {
 
     public static final String UTF_8 = "UTF-8";
-    public static final String QUERY_DELIMETER = "&";
-    public static final String KEY_VALUE_DELIMETER = "=";
+    public static final String QUERY_DELIMITER = "&";
+    public static final String KEY_VALUE_DELIMITER = "=";
 
     public static Map<String, String> splitQuery(String query) throws UnsupportedEncodingException {
         Map<String, String> query_pairs = new HashMap<>();
-        String[] pairs = query.split(QUERY_DELIMETER);
+        String[] pairs = query.split(QUERY_DELIMITER);
 
         for (String pair : pairs) {
-            String[] split = pair.split(KEY_VALUE_DELIMETER);
+            String[] split = pair.split(KEY_VALUE_DELIMITER);
             query_pairs.put(URLDecoder.decode(split[0], UTF_8), URLDecoder.decode(split[1], UTF_8));
         }
 

--- a/src/main/java/webserver/utils/Parser.java
+++ b/src/main/java/webserver/utils/Parser.java
@@ -1,0 +1,21 @@
+package webserver.utils;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Parser {
+
+    public static Map<String, String> splitQuery(String query) throws UnsupportedEncodingException {
+        Map<String, String> query_pairs = new HashMap<>();
+        String[] pairs = query.split("&");
+
+        for (String pair : pairs) {
+            String[] split = pair.split("=");
+            query_pairs.put(URLDecoder.decode(split[0], "UTF-8"), URLDecoder.decode(split[1], "UTF-8"));
+        }
+
+        return query_pairs;
+    }
+}

--- a/src/main/java/webserver/utils/Parser.java
+++ b/src/main/java/webserver/utils/Parser.java
@@ -2,18 +2,23 @@ package webserver.utils;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
 public class Parser {
 
+    public static final String UTF_8 = "UTF-8";
+    public static final String QUERY_DELIMETER = "&";
+    public static final String KEY_VALUE_DELIMETER = "=";
+
     public static Map<String, String> splitQuery(String query) throws UnsupportedEncodingException {
         Map<String, String> query_pairs = new HashMap<>();
-        String[] pairs = query.split("&");
+        String[] pairs = query.split(QUERY_DELIMETER);
 
         for (String pair : pairs) {
-            String[] split = pair.split("=");
-            query_pairs.put(URLDecoder.decode(split[0], "UTF-8"), URLDecoder.decode(split[1], "UTF-8"));
+            String[] split = pair.split(KEY_VALUE_DELIMETER);
+            query_pairs.put(URLDecoder.decode(split[0], UTF_8), URLDecoder.decode(split[1], UTF_8));
         }
 
         return query_pairs;

--- a/src/main/java/webserver/utils/TypeMapper.java
+++ b/src/main/java/webserver/utils/TypeMapper.java
@@ -1,4 +1,4 @@
-package webserver;
+package webserver.utils;
 
 import java.io.File;
 import java.util.Map;

--- a/src/main/resources/static/registration/index.html
+++ b/src/main/resources/static/registration/index.html
@@ -23,13 +23,14 @@
       </header>
       <div class="page">
         <h2 class="page-title">회원가입</h2>
-        <form class="form">
+        <form class="form" action="/user/create" method="get">
           <div class="textfield textfield_size_s">
             <p class="title_textfield">아이디</p>
             <input
               class="input_textfield"
               placeholder="아이디를 입력해주세요"
               autocomplete="username"
+              name="userId"
             />
           </div>
           <div class="textfield textfield_size_s">
@@ -38,6 +39,7 @@
               class="input_textfield"
               placeholder="닉네임을 입력해주세요"
               autocomplete="username"
+              name="nickname"
             />
           </div>
           <div class="textfield textfield_size_s">
@@ -47,13 +49,13 @@
               type="password"
               placeholder="비밀번호를 입력해주세요"
               autocomplete="current-password"
+              name="password"
             />
           </div>
           <button
             id="registration-btn"
             class="btn btn_contained btn_size_m"
             style="margin-top: 24px"
-            type="button"
           >
             회원가입
           </button>

--- a/src/main/resources/static/registration/index.html
+++ b/src/main/resources/static/registration/index.html
@@ -23,7 +23,7 @@
       </header>
       <div class="page">
         <h2 class="page-title">회원가입</h2>
-        <form class="form" action="/user/create" method="get">
+        <form class="form" action="/create" method="get">
           <div class="textfield textfield_size_s">
             <p class="title_textfield">아이디</p>
             <input
@@ -34,15 +34,6 @@
             />
           </div>
           <div class="textfield textfield_size_s">
-            <p class="title_textfield">닉네임</p>
-            <input
-              class="input_textfield"
-              placeholder="닉네임을 입력해주세요"
-              autocomplete="username"
-              name="nickname"
-            />
-          </div>
-          <div class="textfield textfield_size_s">
             <p class="title_textfield">비밀번호</p>
             <input
               class="input_textfield"
@@ -50,6 +41,24 @@
               placeholder="비밀번호를 입력해주세요"
               autocomplete="current-password"
               name="password"
+            />
+          </div>
+          <div class="textfield textfield_size_s">
+            <p class="title_textfield">닉네임</p>
+            <input
+                    class="input_textfield"
+                    placeholder="닉네임을 입력해주세요"
+                    autocomplete="username"
+                    name="name"
+            />
+          </div>
+          <div class="textfield textfield_size_s">
+            <p class="title_textfield">이메일</p>
+            <input
+                    class="input_textfield"
+                    placeholder="이메일을 입력해주세요"
+                    autocomplete="email"
+                    name="email"
             />
           </div>
           <button

--- a/src/test/java/TypeMapperTest.java
+++ b/src/test/java/TypeMapperTest.java
@@ -2,7 +2,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import webserver.TypeMapper;
+import webserver.utils.TypeMapper;
 
 import java.io.File;
 

--- a/src/test/java/TypeMapperTest.java
+++ b/src/test/java/TypeMapperTest.java
@@ -1,0 +1,23 @@
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import webserver.TypeMapper;
+
+import java.io.File;
+
+public class TypeMapperTest {
+
+    private static final String STATIC_PATH = "src/resource/static";
+
+
+    @DisplayName("파일에 따라 정해진 Mime 타입을 반환해야 한다.")
+    @ParameterizedTest
+    @CsvSource(value = {"index.html,text/html", "main.css, text/css", "favicon.ico, image/x-icon", "img/like.svg, image/svg+xml"})
+    void typeTest(String filePath, String expectedType) {
+        File file = new File(STATIC_PATH + filePath);
+        String contentType = TypeMapper.getContentType(file);
+
+        Assertions.assertThat(contentType).isEqualTo(expectedType);
+    }
+}


### PR DESCRIPTION
## 구현 내용
- RequestHandler의 run 메서드의 코드를 HttpRequest, HttpResponse 클래스로 분할
- URI에 따라 정해진 메서드를 실행하는 `RequestMapper` 구현
  - `Map<String, Function>`으로 미리 정의해둔 URI가 들어오면 특정 메서드를 실행
  - 메서드는 유저 회원 가입 등 로직을 처리하고 HTTP 응답을 반환
  - 매칭되는 URI가 없으면 해당 경로에 위치한 정적 파일을 body에 담은 HTTP 응답을 반환
- 파일 타입에 맞는 Content-type 을 찾기 위한 `TypeMapper` 구현
- 쿼리 파라미터 파싱을 위한 `Parser` 클래스 구현
- 회원 가입 기능 구현
  - 쿼리 파라미터를 파싱해 `Map`으로 저장하는 로직 추가
  - 유저 정보가 들어있는 `Map` 객체를 받아 `User` 객체를 반환하는 정적 팩토리 메서드 구현  
  - 회원 가입 시 로그인 페이지로 리다이렉션


## 고민 사항
- 파일의 타입을 얻기 위한 `Filse.probeContentType()`가 있는데, nio를 사용하지 못하는 조건 때문에 사용하지 못함
  - .을 기준으로 split 해서 확장자 마다 적합한 content-type을 미리 지정해서 해결
- 쿼리 파라미터를 split 한 뒤에 User 객체로 만드는 역할은 누가 담당해야 할까?
  - `User` 클래스에 정적 팩토리 메서드로 정의
- 그냥 정적 파일을 반환하는 요청과 로직이 들어가는 요청을 어떻게 구분해야 할까?
  - 따로 구분하지 않고, 정의해둔 `URI`가 존재하는지 먼저 확인 한 뒤 매칭되는 `URI`가 없으면 정적 파일을 찾아서 반환
- **회원 가입을 할 때 시크릿 탭에서 가입하면 회원 가입이 정상적으로 되는데, 일반 탭에서 회원가입을 다시하면 잘 안될 때가 있습니다. HTTP 요청을 보면 `/create?....`이 정상적으로 들어오지 않고, 회원가입 후 리다이렉션하도록 한 페이지로 이동만 합니다. 브라우저에 쿠키에 정보가 저장되어서 그런걸로 추측하고 있는데 정확한 이유를 아직 모르겠습니다.**


## 기타
### css와 이미지 파일에 맞는 content type을 헤더에 제공해 정상적으로 적용됨을 확인했습니다.
<img width="1458" alt="스크린샷 2024-03-14 오후 5 01 36" src="https://github.com/codesquad-members-2024/be-was-neon/assets/110909423/6d3e7758-0b60-46f5-b6e7-6463dfb9009b">

### 회원 가입 시 유저 정보가 저장 됨을 로그로 찍어 확인했습니다.
```
16:50:49.868 [DEBUG] [pool-17-thread-1] [webserver.RequestMapper] - User created : User [userId=cori, password=1234, name=cori, email=cori@naver.com]
```
