### PR TITLE
[Sid] Step-3 다양한 컨텐츠 타입 지원

### DIFF
--- a/src/main/java/webserver/ContentType.java
+++ b/src/main/java/webserver/ContentType.java
@@ -1,0 +1,37 @@
+package webserver;
+
+import java.util.Arrays;
+
+public enum ContentType {
+    HTML(".html", "text/html"),
+    CSS(".css", "text/css"),
+    JS(".js", "text/javascript"),
+    ICO(".ico", "image/x-icon"),
+    PNG(".png", "image/png"),
+    JPG(".jpg", "image/jpeg"),
+    SVG(".svg", "image/svg+xml"),
+    NONE("", "");
+
+    private final String extension;
+    private final String mimeType;
+
+    ContentType(String extension, String mimeType) {
+        this.extension = extension;
+        this.mimeType = mimeType;
+    }
+
+    public String getExtension() {
+        return extension;
+    }
+
+    public String getMimetype() {
+        return mimeType;
+    }
+
+    public static ContentType findMatchingContentType(String requestLine){
+        return Arrays.stream(values())
+                .filter(v -> requestLine.contains(v.getExtension()))
+                .findFirst()
+                .orElse(NONE);
+    }
+}

--- a/src/main/java/webserver/DefaultFileHandler.java
+++ b/src/main/java/webserver/DefaultFileHandler.java
@@ -3,9 +3,9 @@ package webserver;
 import webserver.exceptions.ResourceNotFoundException;
 
 public class DefaultFileHandler {
-    private final HttpRequestMsg httpRequestMessage;
+    private final HttpRequest httpRequestMessage;
 
-    public DefaultFileHandler(HttpRequestMsg httpRequestMessage) {
+    public DefaultFileHandler(HttpRequest httpRequestMessage) {
         this.httpRequestMessage = httpRequestMessage;
     }
 

--- a/src/main/java/webserver/DefaultFileHandler.java
+++ b/src/main/java/webserver/DefaultFileHandler.java
@@ -16,7 +16,6 @@ public class DefaultFileHandler {
         String requestTarget = httpRequestMessage.getRequestTarget();
 
         String path = redirector.makeRedirection(requestTarget);
-        String data = loader.load(path);
-        return data.getBytes();
+        return loader.load(path);
     }
 }

--- a/src/main/java/webserver/HttpRequest.java
+++ b/src/main/java/webserver/HttpRequest.java
@@ -3,7 +3,7 @@ package webserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class HttpRequestMsg {
+public class HttpRequest {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
     private String method;
     private String requestTarget;
@@ -11,7 +11,7 @@ public class HttpRequestMsg {
     private String headers;
     private String body;
 
-    public HttpRequestMsg(String msg){
+    public HttpRequest(String msg){
         parseMsg(msg);
     }
 

--- a/src/main/java/webserver/HttpRequestMsg.java
+++ b/src/main/java/webserver/HttpRequestMsg.java
@@ -7,6 +7,7 @@ public class HttpRequestMsg {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
     private String method;
     private String requestTarget;
+    private ContentType contentType;
     private String headers;
     private String body;
 
@@ -22,12 +23,20 @@ public class HttpRequestMsg {
         return requestTarget;
     }
 
+    public ContentType getContentType() {
+        return contentType;
+    }
+
     public String getHeaders() {
         return headers;
     }
 
     public String getBody() {
         return body;
+    }
+
+    public boolean requireStaticFile() {
+        return !contentType.equals(ContentType.NONE);
     }
 
     private void parseMsg(String msg) {
@@ -50,5 +59,6 @@ public class HttpRequestMsg {
     private void parseRequestLine(String requestLine) {
         this.method = requestLine.split(" ")[0];
         this.requestTarget = requestLine.split(" ")[1];
+        this.contentType = ContentType.findMatchingContentType(requestTarget);
     }
 }

--- a/src/main/java/webserver/HttpResponse.java
+++ b/src/main/java/webserver/HttpResponse.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class HttpResponseMsg {
+public class HttpResponse {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
 
     private static final String BLANK = " ";
@@ -21,14 +21,14 @@ public class HttpResponseMsg {
     private final ContentType contentType;
     private final byte[] body;
 
-    public HttpResponseMsg(int statusCode, String reasonPhrase, ContentType contentType, byte[] body){
+    public HttpResponse(int statusCode, String reasonPhrase, ContentType contentType, byte[] body){
         this.statusCode = statusCode;
         this.reasonPhrase = reasonPhrase;
         this.contentType = contentType;
         this.body = body;
     }
 
-    public HttpResponseMsg(int statusCode, String reasonPhrase, byte[] body){
+    public HttpResponse(int statusCode, String reasonPhrase, byte[] body){
         this.statusCode = statusCode;
         this.reasonPhrase = reasonPhrase;
         this.contentType = ContentType.NONE;
@@ -36,7 +36,7 @@ public class HttpResponseMsg {
     }
 
     // 별도의 body 내용 없이 메시지를 보내는 경우 사용
-    public HttpResponseMsg(int statusCode, String reasonPhrase){
+    public HttpResponse(int statusCode, String reasonPhrase){
         this.statusCode = statusCode;
         this.reasonPhrase = reasonPhrase;
         this.contentType = ContentType.NONE;

--- a/src/main/java/webserver/HttpResponseMsg.java
+++ b/src/main/java/webserver/HttpResponseMsg.java
@@ -11,19 +11,28 @@ public class HttpResponseMsg {
 
     private final int statusCode;
     private final String reasonPhrase;
+    private final ContentType contentType;
     private final byte[] body;
+
+    public HttpResponseMsg(int statusCode, String reasonPhrase, ContentType contentType, byte[] body){
+        this.statusCode = statusCode;
+        this.reasonPhrase = reasonPhrase;
+        this.contentType = contentType;
+        this.body = body;
+    }
 
     public HttpResponseMsg(int statusCode, String reasonPhrase, byte[] body){
         this.statusCode = statusCode;
         this.reasonPhrase = reasonPhrase;
+        this.contentType = ContentType.NONE;
         this.body = body;
     }
 
     // 별도의 body 내용 없이 메시지를 보내는 경우 사용
-
     public HttpResponseMsg(int statusCode, String reasonPhrase){
         this.statusCode = statusCode;
         this.reasonPhrase = reasonPhrase;
+        this.contentType = ContentType.NONE;
         this.body = new byte[0];
     }
 
@@ -34,8 +43,8 @@ public class HttpResponseMsg {
 
     private void writeResponseHeader(DataOutputStream dos) {
         try {
-            dos.writeBytes("HTTP/1.1 " + statusCode + reasonPhrase + " \r\n");
-            dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
+            dos.writeBytes("HTTP/1.1 " + statusCode + " " + reasonPhrase + " \r\n");
+            dos.writeBytes("Content-Type:" + contentType.getMimetype() + ";charset=utf-8 \r\n");
             dos.writeBytes("Content-Length: " + body.length + "\r\n");
             dos.writeBytes("\r\n");
         } catch (IOException e) {
@@ -59,6 +68,7 @@ public class HttpResponseMsg {
     public String getReasonPhrase() {
         return reasonPhrase;
     }
+
     public byte[] getBody() {
         return body;
     }

--- a/src/main/java/webserver/HttpResponseMsg.java
+++ b/src/main/java/webserver/HttpResponseMsg.java
@@ -9,6 +9,13 @@ import org.slf4j.LoggerFactory;
 public class HttpResponseMsg {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
 
+    private static final String BLANK = " ";
+    private static final String SEMICOLON = ";";
+    private static final String HTTP_VERSION_HEADER = "HTTP/";
+    private final String HTTP_VERSION = "1.1";
+    private static final String CONTENT_TYPE_HEADER = "Content-Type:";
+    private static final String CONTENT_LENGTH_HEADER = "Content-Length:";
+    private static final String CRLF = "\r\n";
     private final int statusCode;
     private final String reasonPhrase;
     private final ContentType contentType;
@@ -37,28 +44,23 @@ public class HttpResponseMsg {
     }
 
     public void send(DataOutputStream dos) {
-        writeResponseHeader(dos);
-        writeResponseBody(dos);
-    }
-
-    private void writeResponseHeader(DataOutputStream dos) {
+        String header = makeHeader();
         try {
-            dos.writeBytes("HTTP/1.1 " + statusCode + " " + reasonPhrase + " \r\n");
-            dos.writeBytes("Content-Type:" + contentType.getMimetype() + ";charset=utf-8 \r\n");
-            dos.writeBytes("Content-Length: " + body.length + "\r\n");
-            dos.writeBytes("\r\n");
-        } catch (IOException e) {
-            logger.error(e.getMessage());
-        }
-    }
-
-    private void writeResponseBody(DataOutputStream dos) {
-        try {
+            dos.writeBytes(header);
             dos.write(body, 0, body.length);
             dos.flush();
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
+    }
+
+    private String makeHeader() {
+        StringBuilder headerBuilder = new StringBuilder();
+        headerBuilder.append(HTTP_VERSION_HEADER + HTTP_VERSION + statusCode + BLANK + reasonPhrase + BLANK + CRLF);
+        headerBuilder.append(CONTENT_TYPE_HEADER + BLANK + contentType.getMimetype() + SEMICOLON + "charset=utf-8" + BLANK + CRLF);
+        headerBuilder.append(CONTENT_LENGTH_HEADER + BLANK + body.length + CRLF);
+        headerBuilder.append(CRLF);
+        return headerBuilder.toString();
     }
 
     public int getStatusCode() {

--- a/src/main/java/webserver/HttpStatus.java
+++ b/src/main/java/webserver/HttpStatus.java
@@ -1,0 +1,23 @@
+package webserver;
+
+public enum HttpStatus {
+    OK(200, "OK"),
+    BAD_REQUEST(400, "Bad Request"),
+    NOT_FOUND(404, "Not Found");
+
+    private final int statusCode;
+    private final String reasonPhrase;
+
+    HttpStatus(int statusCode, String reasonPhrase) {
+        this.statusCode = statusCode;
+        this.reasonPhrase = reasonPhrase;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public String getReasonPhrase() {
+        return reasonPhrase;
+    }
+}

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -24,15 +24,15 @@ public class RequestHandler implements Runnable {
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             BufferedReader br = Reader.inputStreamToBufferedReader(in);
             String msg = Reader.bufferedReaderToString(br);
-            HttpRequestMsg httpRequestMsg = new HttpRequestMsg(msg);
+            HttpRequest httpRequest = new HttpRequest(msg);
 
             // HTTP 헤더에서 requestTarget 추출, 알맞는 핸들러 호출 후 결과 반환
             Router router = new Router();
-            HttpResponseMsg httpResponseMsg = router.route(httpRequestMsg);
+            HttpResponse httpResponse = router.route(httpRequest);
 
             // 처리 결과를 바탕으로 HTTP 응답 메시지를 만들어 클라이언트에 전송
             DataOutputStream dos = new DataOutputStream(out);
-            httpResponseMsg.send(dos);
+            httpResponse.send(dos);
         } catch (IOException e) {
             logger.error(e.getMessage());
         }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -6,6 +6,7 @@ import java.net.Socket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import util.Reader;
+import webserver.router.Router;
 
 public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);

--- a/src/main/java/webserver/ResourceLoader.java
+++ b/src/main/java/webserver/ResourceLoader.java
@@ -2,18 +2,15 @@ package webserver;
 
 import webserver.exceptions.ResourceNotFoundException;
 
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
+import java.io.*;
 
 public class ResourceLoader {
-    public String load(String path) throws ResourceNotFoundException {
+    public byte[] load(String path) throws ResourceNotFoundException {
         File targetFile = new File(path);
-        // TODO: String 말고 byte[] 반환으로 변경
-        try (FileReader fileReader = new FileReader(targetFile)){
-            char[] chars = new char[(int) targetFile.length()];
-            fileReader.read(chars);
-            return new String(chars);
+        byte[] byteArray = new byte[(int) targetFile.length()];
+        try (FileInputStream inputStream = new FileInputStream(targetFile)) {
+            inputStream.read(byteArray);
+            return byteArray;
         } catch (IOException e) {
             throw new ResourceNotFoundException("요청한 %s 리소스가 존재하지 않습니다", path);
         }

--- a/src/main/java/webserver/ResourceLoader.java
+++ b/src/main/java/webserver/ResourceLoader.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 public class ResourceLoader {
     public String load(String path) throws ResourceNotFoundException {
         File targetFile = new File(path);
+        // TODO: String 말고 byte[] 반환으로 변경
         try (FileReader fileReader = new FileReader(targetFile)){
             char[] chars = new char[(int) targetFile.length()];
             fileReader.read(chars);

--- a/src/main/java/webserver/Router.java
+++ b/src/main/java/webserver/Router.java
@@ -3,16 +3,14 @@ package webserver;
 import webserver.exceptions.ResourceNotFoundException;
 import webserver.exceptions.UrlFormatException;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 public class Router {
-    private final String INITIAL_PATH_SEGMENT_EXTRACTION_PATTERN = "^\\/[^\\/\\?]+";
+
 
     public HttpResponseMsg route(HttpRequestMsg httpRequestMsg) {
         // HTTP 요청 메시지 정보를 바탕으로 적절한 핸들러 객체를 생성 호출하고, 해당 객체의 결과를 바탕으로 응답 메시지를 작성한다
         try{
-            String targetHandler = extractTargetHandler(httpRequestMsg);
+            TargetHandlerExtractor extractor = new TargetHandlerExtractor();
+            String targetHandler = extractor.extractTargetHandler(httpRequestMsg);
             switch (targetHandler) {
                 case "/create" -> {
                     UserCreateHandler userCreateHandler = new UserCreateHandler();
@@ -32,18 +30,6 @@ public class Router {
             return new HttpResponseMsg(400, "Bad Request: " + e.getMessage());
         } catch (ResourceNotFoundException e) {
             return new HttpResponseMsg(404, "Not Found: " + e.getMessage());
-        }
-    }
-
-    private String extractTargetHandler(HttpRequestMsg httpRequestMsg) throws UrlFormatException {
-        String requestTarget = httpRequestMsg.getRequestTarget();
-        Pattern pattern = Pattern.compile(INITIAL_PATH_SEGMENT_EXTRACTION_PATTERN);
-        Matcher matcher = pattern.matcher(requestTarget);
-        if (matcher.find()) {
-            return matcher.group();
-        }
-        else {
-            throw new UrlFormatException("잘못된 형식의 URL입니다");
         }
     }
 }

--- a/src/main/java/webserver/TargetHandlerExtractor.java
+++ b/src/main/java/webserver/TargetHandlerExtractor.java
@@ -1,0 +1,20 @@
+package webserver;
+
+import webserver.exceptions.UrlFormatException;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TargetHandlerExtractor {
+    private final String INITIAL_PATH_SEGMENT_EXTRACTION_PATTERN = "^\\/[^\\/\\?]+";
+    public String extractTargetHandler(HttpRequestMsg httpRequestMsg) throws UrlFormatException {
+        String requestTarget = httpRequestMsg.getRequestTarget();
+        Pattern pattern = Pattern.compile(INITIAL_PATH_SEGMENT_EXTRACTION_PATTERN);
+        Matcher matcher = pattern.matcher(requestTarget);
+        if (matcher.find()) {
+            return matcher.group();
+        } else {
+            throw new UrlFormatException("잘못된 형식의 URL입니다");
+        }
+    }
+}

--- a/src/main/java/webserver/TargetHandlerExtractor.java
+++ b/src/main/java/webserver/TargetHandlerExtractor.java
@@ -7,8 +7,8 @@ import java.util.regex.Pattern;
 
 public class TargetHandlerExtractor {
     private final String INITIAL_PATH_SEGMENT_EXTRACTION_PATTERN = "^\\/[^\\/\\?]+";
-    public String extractTargetHandler(HttpRequestMsg httpRequestMsg) throws UrlFormatException {
-        String requestTarget = httpRequestMsg.getRequestTarget();
+    public String extractTargetHandler(HttpRequest httpRequest) throws UrlFormatException {
+        String requestTarget = httpRequest.getRequestTarget();
         Pattern pattern = Pattern.compile(INITIAL_PATH_SEGMENT_EXTRACTION_PATTERN);
         Matcher matcher = pattern.matcher(requestTarget);
         if (matcher.find()) {

--- a/src/main/java/webserver/router/DynamicRouter.java
+++ b/src/main/java/webserver/router/DynamicRouter.java
@@ -5,28 +5,28 @@ import webserver.exceptions.ResourceNotFoundException;
 import webserver.exceptions.UrlFormatException;
 
 public class DynamicRouter {
-    public HttpResponseMsg route(HttpRequestMsg httpRequestMsg) {
+    public HttpResponse route(HttpRequest httpRequest) {
         try {
             TargetHandlerExtractor extractor = new TargetHandlerExtractor();
-            String targetHandler = extractor.extractTargetHandler(httpRequestMsg);
+            String targetHandler = extractor.extractTargetHandler(httpRequest);
             switch (targetHandler) {
                 case "/create" -> {
                     UserCreateHandler userCreateHandler = new UserCreateHandler();
-                    userCreateHandler.addUserInDatabase(httpRequestMsg.getRequestTarget());
-                    return new HttpResponseMsg(200, "OK");
+                    userCreateHandler.addUserInDatabase(httpRequest.getRequestTarget());
+                    return new HttpResponse(200, "OK");
                 }
                 case "/registration" -> {
-                    DefaultFileHandler defaultFileHandler = new DefaultFileHandler(httpRequestMsg);
-                    return new HttpResponseMsg(200, "OK", defaultFileHandler.serialize());
+                    DefaultFileHandler defaultFileHandler = new DefaultFileHandler(httpRequest);
+                    return new HttpResponse(200, "OK", defaultFileHandler.serialize());
                 }
                 default -> {
-                    return new HttpResponseMsg(404, "Not Found: 요청한 리소스를 찾을 수 없습니다");
+                    return new HttpResponse(404, "Not Found: 요청한 리소스를 찾을 수 없습니다");
                 }
             }
         } catch (UrlFormatException e) {
-            return new HttpResponseMsg(400, "Bad Request: " + e.getMessage());
+            return new HttpResponse(400, "Bad Request: " + e.getMessage());
         } catch (ResourceNotFoundException e) {
-            return new HttpResponseMsg(404, "Not Found: " + e.getMessage());
+            return new HttpResponse(404, "Not Found: " + e.getMessage());
         }
     }
 }

--- a/src/main/java/webserver/router/DynamicRouter.java
+++ b/src/main/java/webserver/router/DynamicRouter.java
@@ -1,14 +1,12 @@
-package webserver;
+package webserver.router;
 
+import webserver.*;
 import webserver.exceptions.ResourceNotFoundException;
 import webserver.exceptions.UrlFormatException;
 
-public class Router {
-
-
+public class DynamicRouter {
     public HttpResponseMsg route(HttpRequestMsg httpRequestMsg) {
-        // HTTP 요청 메시지 정보를 바탕으로 적절한 핸들러 객체를 생성 호출하고, 해당 객체의 결과를 바탕으로 응답 메시지를 작성한다
-        try{
+        try {
             TargetHandlerExtractor extractor = new TargetHandlerExtractor();
             String targetHandler = extractor.extractTargetHandler(httpRequestMsg);
             switch (targetHandler) {
@@ -17,7 +15,7 @@ public class Router {
                     userCreateHandler.addUserInDatabase(httpRequestMsg.getRequestTarget());
                     return new HttpResponseMsg(200, "OK");
                 }
-                case "/index.html", "/register.html", "/registration" -> {
+                case "/registration" -> {
                     DefaultFileHandler defaultFileHandler = new DefaultFileHandler(httpRequestMsg);
                     return new HttpResponseMsg(200, "OK", defaultFileHandler.serialize());
                 }
@@ -25,7 +23,6 @@ public class Router {
                     return new HttpResponseMsg(404, "Not Found: 요청한 리소스를 찾을 수 없습니다");
                 }
             }
-            // 핸들러 객체 등에서 에러가 발생하는 경우, 에러를 잡고 그 에러를 바탕으로 응답 메시지를 반환한다
         } catch (UrlFormatException e) {
             return new HttpResponseMsg(400, "Bad Request: " + e.getMessage());
         } catch (ResourceNotFoundException e) {

--- a/src/main/java/webserver/router/DynamicRouter.java
+++ b/src/main/java/webserver/router/DynamicRouter.java
@@ -13,20 +13,19 @@ public class DynamicRouter {
                 case "/create" -> {
                     UserCreateHandler userCreateHandler = new UserCreateHandler();
                     userCreateHandler.addUserInDatabase(httpRequest.getRequestTarget());
-                    return new HttpResponse(200, "OK");
+                    return new HttpResponse(HttpStatus.OK.getStatusCode(), HttpStatus.OK.getReasonPhrase());
                 }
                 case "/registration" -> {
                     DefaultFileHandler defaultFileHandler = new DefaultFileHandler(httpRequest);
-                    return new HttpResponse(200, "OK", defaultFileHandler.serialize());
+                    return new HttpResponse(HttpStatus.OK.getStatusCode(), HttpStatus.OK.getReasonPhrase(), defaultFileHandler.serialize());
                 }
                 default -> {
-                    return new HttpResponse(404, "Not Found: 요청한 리소스를 찾을 수 없습니다");
+                    return new HttpResponse(HttpStatus.NOT_FOUND.getStatusCode()
+                            , HttpStatus.NOT_FOUND.getReasonPhrase() + "요청한 리소스를 찾을 수 없습니다");
                 }
             }
-        } catch (UrlFormatException e) {
-            return new HttpResponse(400, "Bad Request: " + e.getMessage());
-        } catch (ResourceNotFoundException e) {
-            return new HttpResponse(404, "Not Found: " + e.getMessage());
+        } catch (UrlFormatException | ResourceNotFoundException e) {
+            return new HttpResponse(HttpStatus.BAD_REQUEST.getStatusCode(), HttpStatus.BAD_REQUEST.getReasonPhrase() + e.getMessage());
         }
     }
 }

--- a/src/main/java/webserver/router/Router.java
+++ b/src/main/java/webserver/router/Router.java
@@ -1,0 +1,16 @@
+package webserver.router;
+
+
+import webserver.HttpRequestMsg;
+import webserver.HttpResponseMsg;
+
+public class Router {
+
+    public HttpResponseMsg route(HttpRequestMsg httpRequestMsg) {
+        if (httpRequestMsg.requireStaticFile()) {
+            return new StaticRouter().route(httpRequestMsg);
+        } else {
+            return new DynamicRouter().route(httpRequestMsg);
+        }
+    }
+}

--- a/src/main/java/webserver/router/Router.java
+++ b/src/main/java/webserver/router/Router.java
@@ -1,16 +1,16 @@
 package webserver.router;
 
 
-import webserver.HttpRequestMsg;
-import webserver.HttpResponseMsg;
+import webserver.HttpRequest;
+import webserver.HttpResponse;
 
 public class Router {
 
-    public HttpResponseMsg route(HttpRequestMsg httpRequestMsg) {
-        if (httpRequestMsg.requireStaticFile()) {
-            return new StaticRouter().route(httpRequestMsg);
+    public HttpResponse route(HttpRequest httpRequest) {
+        if (httpRequest.requireStaticFile()) {
+            return new StaticRouter().route(httpRequest);
         } else {
-            return new DynamicRouter().route(httpRequestMsg);
+            return new DynamicRouter().route(httpRequest);
         }
     }
 }

--- a/src/main/java/webserver/router/StaticRouter.java
+++ b/src/main/java/webserver/router/StaticRouter.java
@@ -1,9 +1,6 @@
 package webserver.router;
 
-import webserver.DefaultFileHandler;
-import webserver.HttpRequest;
-import webserver.HttpResponse;
-import webserver.TargetHandlerExtractor;
+import webserver.*;
 import webserver.exceptions.ResourceNotFoundException;
 import webserver.exceptions.UrlFormatException;
 
@@ -14,11 +11,11 @@ public class StaticRouter {
             String targetHandler = extractor.extractTargetHandler(httpRequest);
             DefaultFileHandler defaultFileHandler = new DefaultFileHandler(httpRequest);
             byte[] body = defaultFileHandler.serialize();
-            return new HttpResponse(200, "OK", httpRequest.getContentType(), body);
+            return new HttpResponse(HttpStatus.OK.getStatusCode(), HttpStatus.OK.getReasonPhrase(), httpRequest.getContentType(), body);
         } catch (UrlFormatException e) {
-            return new HttpResponse(400, "Bad Request: " + e.getMessage());
+            return new HttpResponse(HttpStatus.BAD_REQUEST.getStatusCode(), HttpStatus.BAD_REQUEST.getReasonPhrase() + e.getMessage());
         } catch (ResourceNotFoundException e) {
-            return new HttpResponse(404, "Not Found: " + e.getMessage());
+            return new HttpResponse(HttpStatus.NOT_FOUND.getStatusCode(), HttpStatus.NOT_FOUND.getReasonPhrase() + e.getMessage());
         }
     }
 }

--- a/src/main/java/webserver/router/StaticRouter.java
+++ b/src/main/java/webserver/router/StaticRouter.java
@@ -1,24 +1,24 @@
 package webserver.router;
 
 import webserver.DefaultFileHandler;
-import webserver.HttpRequestMsg;
-import webserver.HttpResponseMsg;
+import webserver.HttpRequest;
+import webserver.HttpResponse;
 import webserver.TargetHandlerExtractor;
 import webserver.exceptions.ResourceNotFoundException;
 import webserver.exceptions.UrlFormatException;
 
 public class StaticRouter {
-    public HttpResponseMsg route(HttpRequestMsg httpRequestMsg) {
+    public HttpResponse route(HttpRequest httpRequest) {
         try {
             TargetHandlerExtractor extractor = new TargetHandlerExtractor();
-            String targetHandler = extractor.extractTargetHandler(httpRequestMsg);
-            DefaultFileHandler defaultFileHandler = new DefaultFileHandler(httpRequestMsg);
+            String targetHandler = extractor.extractTargetHandler(httpRequest);
+            DefaultFileHandler defaultFileHandler = new DefaultFileHandler(httpRequest);
             byte[] body = defaultFileHandler.serialize();
-            return new HttpResponseMsg(200, "OK", httpRequestMsg.getContentType(), body);
+            return new HttpResponse(200, "OK", httpRequest.getContentType(), body);
         } catch (UrlFormatException e) {
-            return new HttpResponseMsg(400, "Bad Request: " + e.getMessage());
+            return new HttpResponse(400, "Bad Request: " + e.getMessage());
         } catch (ResourceNotFoundException e) {
-            return new HttpResponseMsg(404, "Not Found: " + e.getMessage());
+            return new HttpResponse(404, "Not Found: " + e.getMessage());
         }
     }
 }

--- a/src/main/java/webserver/router/StaticRouter.java
+++ b/src/main/java/webserver/router/StaticRouter.java
@@ -1,0 +1,24 @@
+package webserver.router;
+
+import webserver.DefaultFileHandler;
+import webserver.HttpRequestMsg;
+import webserver.HttpResponseMsg;
+import webserver.TargetHandlerExtractor;
+import webserver.exceptions.ResourceNotFoundException;
+import webserver.exceptions.UrlFormatException;
+
+public class StaticRouter {
+    public HttpResponseMsg route(HttpRequestMsg httpRequestMsg) {
+        try {
+            TargetHandlerExtractor extractor = new TargetHandlerExtractor();
+            String targetHandler = extractor.extractTargetHandler(httpRequestMsg);
+            DefaultFileHandler defaultFileHandler = new DefaultFileHandler(httpRequestMsg);
+            byte[] body = defaultFileHandler.serialize();
+            return new HttpResponseMsg(200, "OK", httpRequestMsg.getContentType(), body);
+        } catch (UrlFormatException e) {
+            return new HttpResponseMsg(400, "Bad Request: " + e.getMessage());
+        } catch (ResourceNotFoundException e) {
+            return new HttpResponseMsg(404, "Not Found: " + e.getMessage());
+        }
+    }
+}

--- a/src/test/java/webserver/ContentTypeTest.java
+++ b/src/test/java/webserver/ContentTypeTest.java
@@ -1,0 +1,28 @@
+package webserver;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ContentTypeTest {
+
+    static Stream<Arguments> requestLineAndContentType() {
+        return Stream.of(
+                Arguments.arguments("GET /index.html HTTP/1.1", ContentType.HTML),
+                Arguments.arguments("GET /reset.csss HTTP/1.1", ContentType.CSS),
+                Arguments.arguments("GET /registration HTTP/1.1", ContentType.NONE)
+        );
+    }
+
+    @DisplayName("HTTP 요청 메시지 중 request line에서 콘텐츠 반환을 요청하는 경우, 그에 맞는 콘텐츠 타입을 반환한다")
+    @ParameterizedTest
+    @MethodSource("requestLineAndContentType")
+    void findMatchingContentTypeTest(String requestLine, ContentType contentType) {
+        assertThat(ContentType.findMatchingContentType(requestLine)).isEqualTo(contentType);
+    }
+}

--- a/src/test/java/webserver/HttpRequestTest.java
+++ b/src/test/java/webserver/HttpRequestTest.java
@@ -6,9 +6,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class HttpRequestMsgTest {
+class HttpRequestTest {
 
-    HttpRequestMsg msg;
+    HttpRequest msg;
 
     private String msgExample =
             """
@@ -21,7 +21,7 @@ class HttpRequestMsgTest {
 
     @BeforeEach
     void setMsg(){
-        msg = new HttpRequestMsg(msgExample);
+        msg = new HttpRequest(msgExample);
     }
 
     @Test
@@ -37,7 +37,7 @@ class HttpRequestMsgTest {
     }
 
     @Test
-    @DisplayName("예시 http요청 메시지 중 header를 추출한다")
+    @DisplayName("예시 http요청 메시지 중 Request Line과 header를 추출한다")
     void getHeadersTest() {
         String answer = """
                 GET /index.html HTTP/1.1

--- a/src/test/java/webserver/ResourceLoaderTest.java
+++ b/src/test/java/webserver/ResourceLoaderTest.java
@@ -1,13 +1,9 @@
 package webserver;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import webserver.exceptions.ResourceNotFoundException;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 class ResourceLoaderTest {
@@ -15,27 +11,11 @@ class ResourceLoaderTest {
 
     private ResourceLoader resourceLoader;
 
-    @BeforeEach
-    void setResourceLoader() {
-        this.resourceLoader = new ResourceLoader();
-    }
-
-    @DisplayName("요청한 경로에 있는 파일을 읽어 string으로 변환한다")
-    @ParameterizedTest(name = "{index}) 경로: {0}")
-    @CsvSource({
-            "/registration/register.html, 아이디를 입력해주세요",
-            "/index.html, 우리는 시스템 아키텍처에 대한 일관성 있는 접근이 필요하며"
-    } )
-    void loadTest(String path, String content) throws ResourceNotFoundException {
-        String loadResult = resourceLoader.load(BASE_URL + path);
-        assertThat(loadResult.contains(content)).isTrue();
-    }
-
     @DisplayName("요청한 경로에 리소스가 없는 경우 ResourceNotFoundException 예외를 발생시킨다")
     @Test
     void loadExceptionTest() throws ResourceNotFoundException {
         String invalidPath = "./src/main/resources/static/inqeux.html";
-        assertThatThrownBy(() -> resourceLoader.load(invalidPath))
+        assertThatThrownBy(() -> new ResourceLoader().load(invalidPath))
                 .isInstanceOf(ResourceNotFoundException.class);
     }
 }

--- a/src/test/java/webserver/RouterTest.java
+++ b/src/test/java/webserver/RouterTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import webserver.router.Router;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/webserver/RouterTest.java
+++ b/src/test/java/webserver/RouterTest.java
@@ -37,10 +37,10 @@ class RouterTest {
                 """;
 
         String requestExample = String.format(requestTemplate, requestPath);
-        HttpRequestMsg httpRequestMsg = new HttpRequestMsg(requestExample);
+        HttpRequest httpRequest = new HttpRequest(requestExample);
 
-        HttpResponseMsg actualResponseMsg = router.route(httpRequestMsg);
-        HttpResponseMsg expectedResponseMsg = new HttpResponseMsg(expectedStatusCode, expectedReasonPhrase);
+        HttpResponse actualResponseMsg = router.route(httpRequest);
+        HttpResponse expectedResponseMsg = new HttpResponse(expectedStatusCode, expectedReasonPhrase);
 
         assertThat(actualResponseMsg.getStatusCode()).isEqualTo(expectedResponseMsg.getStatusCode());
         assertThat(actualResponseMsg.getReasonPhrase()).isEqualTo(expectedResponseMsg.getReasonPhrase());


### PR DESCRIPTION
## 구현 내용
- 다양한 콘텐츠 타입을 지원하기 위한 클래스 추가, 기존 클래스 수정
  - `ContentType` 
    - 콘텐츠 타입 별 확장자와 MIME 타입을 Enum 형태로 관리
  - `HttpRequest`, `HttpResponse`
    - 메시지 안에서 `Content Type`정보를 가질 수 있도록 수정

- `Router`, `StaticRouter`, `DynamicRouter`
  - 기존 모든 요청을 처리하던 Router를 정적 파일을 돌려주는 기능을 담당하는 `StaticRouter`, 별도의 추가 작업이 필요한 요청을 처리하는 `DynamicRouter`로 기능 분리

![Class Diagram](https://github.com/codesquad-members-2024/be-was-neon/assets/109015852/a0b51930-9da8-4261-99f2-408b7c685d8e)


## 고민 사항
- 'StaticRouter', 'DynamicRouter'라는 네이밍이 적절한 네이밍일지 고민이 됩니다.
  - 특히 'Dynamic'이라고 이름 지을지 'APIRouter'라고 이름을 붙일지 고민이 되었습니다
  - 둘의 구분이 모호한 경우는 어떻게 해야 할지 고민이 되었습니다. 예를 들어 '/registration'이라는 요청은 Dynamic 처럼 보이지만, 사실상 register.html 이라는 정적 파일 반환만 요청하기 때문입니다
