### PR TITLE
[코리] step4-1 POST로 회원가입

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@
   - 리다이렉션
     - 리다이렉션하면 브라우저 URI에 쿼리파라미터가 남지 않게할 수 있다. 
     - `301 Moved Permanently`는 요청 메서드가 GET이 되고, 요청 메시지 바디가 제거될 수 있음
+    - `302 Found`는 `GET` 메서드로 바뀌고, 본문을 제거한다.
+    - `303 See Other`은 `302`와 동작은 같지만, 메서드 변경과 본문제거가 보장된다.
     - `308 Permanent Redirect`는 요청 메서드와 바디가 유지
-    - `307 Temporary Redirect`는 
+    - `307 Temporary Redirect`는 `308`과 달리 리다이렉트 요청이 캐싱되지 않는다.
 
 ## 구현 내용
 - Thread 대신 ExecutorService 를 사용하도록 리팩토링

--- a/README.md
+++ b/README.md
@@ -31,9 +31,31 @@
   - 유저 정보가 들어있는 `Map` 객체를 받아 `User` 객체를 반환하는 정적 팩토리 메서드 구현  
   - 회원 가입 시 로그인 페이지로 리다이렉션
 - 테스트 코드 작성
+- POST 회원가입 구현
+- 회원가입 성공 시 홈 화면으로 리다이렉션  
 
 ## 요청 타겟 별 기능
 - `/` : `index.html` 을 반환
 - `/login` : `login/index.html` 반환
 - `/registration` : `registration/index.html`
 - `/create` : 쿼리 파라미터의 값으로 User 객체를 만들어 저장 후 로그인 페이지로 리다이렉트
+
+
+## 고민사항
+- HTTP 요청의 body가 비어있을 경우 처리
+HTTP 요청의 바디가 없을 경우 빈 `Map`을 리턴하는 로직을 작성하던 중 `contentLength == null`과 `return Map.of()` 부분이 어색하게 느껴집니다.  
+```java
+private static Map<String, String> readBody(BufferedReader br, String contentLength) throws IOException {
+        if (contentLength == null) {
+            return Map.of();
+        }
+
+        String body = readBodyContent(br, contentLength);
+        return Parser.parseKeyValuePairs(body);
+    }
+```
+
+- 리소스 파일 경로
+현재는 리소스 파일에 접근할 때 경로를 다음과 같이 상수로 정의하고 있습니다.  
+`private static final String STATIC_PATH = "src/main/resources/static"`
+경로를 상수로 정의해두면 실행 환경에 따라 문제가 생길 수 있다고 하는데, 실제로도 상수로 경로를 정의해두는 방법은 잘 사용하지 않는지 궁금합니다.

--- a/src/main/java/webserver/RequestMapper.java
+++ b/src/main/java/webserver/RequestMapper.java
@@ -6,10 +6,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import webserver.httpMessage.HttpRequest;
 import webserver.httpMessage.HttpResponse;
-import webserver.utils.Parser;
 
 import java.io.File;
-import java.io.UnsupportedEncodingException;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -57,15 +55,11 @@ public class RequestMapper {
     }
 
     private static HttpResponse createUser(HttpRequest request) {
-        String queryParams = request.getQueryParams();
-        try {
-            Map<String, String> userForm = Parser.splitQuery(queryParams);
-            User user = User.from(userForm);
-            Database.addUser(user);
-            logger.debug("User created : {}", Database.findUserById(user.getUserId()));
-            return HttpResponse.redirect(LOGIN);
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        Map<String, String> userForm = request.getBody();
+
+        User user = User.from(userForm);
+        Database.addUser(user);
+        logger.debug("User created : {}", Database.findUserById(user.getUserId()));
+        return HttpResponse.redirect(LOGIN);
     }
 }

--- a/src/main/java/webserver/RequestMapper.java
+++ b/src/main/java/webserver/RequestMapper.java
@@ -60,6 +60,6 @@ public class RequestMapper {
         User user = User.from(userForm);
         Database.addUser(user);
         logger.debug("User created : {}", Database.findUserById(user.getUserId()));
-        return HttpResponse.redirect(LOGIN);
+        return HttpResponse.redirect(INDEX_HTML);
     }
 }

--- a/src/main/java/webserver/httpMessage/HttpRequest.java
+++ b/src/main/java/webserver/httpMessage/HttpRequest.java
@@ -2,46 +2,68 @@ package webserver.httpMessage;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import webserver.utils.HttpRequestParser;
 
-import java.io.*;
-import java.util.ArrayList;
-import java.util.List;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Map;
 
 public class HttpRequest {
 
     private static final Logger logger = LoggerFactory.getLogger(HttpRequest.class);
     public static final String NO_QUERY_PARAMS = "";
-    public static final String EMPTY_HTTP_REQUEST_ERROR = "빈 HTTP 요청입니다.";
     public static final String BLANK = " ";
     public static final String REQUEST_TARGET_DELIMITER = "?";
+    public static final String CONTENT_LENGTH = "Content-Length";
 
-    private final List<String> httpRequest;
     private final String startLine;
     private final String requestTarget;
+    private final Map<String, String> header;
+    private final Map<String, String> body;
 
-    public HttpRequest(List<String> httpRequest) {
-        validate(httpRequest);
-        this.httpRequest = httpRequest;
-        this.startLine = httpRequest.get(0);
+    public HttpRequest(String startLine, Map<String, String> header, Map<String, String> body) {
+        this.startLine = startLine;
         this.requestTarget = getRequestTarget();
-    }
-
-    private void validate(List<String> httpRequest) {
-        if (httpRequest.isEmpty()) {
-            throw new IllegalArgumentException(EMPTY_HTTP_REQUEST_ERROR);
-        }
+        this.header = header;
+        this.body = body;
     }
 
     public static HttpRequest from(InputStream in) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(in));
-        List<String> httpRequest = new ArrayList<>();
 
-        String line;
-        while (!(line = br.readLine()).isEmpty()) {
-            httpRequest.add(line);
+        String startLine = br.readLine();
+        Map<String, String> header = readHeader(br);
+        Map<String, String> body = readBody(br, header.get(CONTENT_LENGTH));
+        return new HttpRequest(startLine, header, body);
+    }
+
+    private static Map<String, String> readBody(BufferedReader br, String contentLength) throws IOException {
+        if (contentLength == null) {
+            return Map.of();
         }
 
-        return new HttpRequest(httpRequest);
+        String body = readBodyContent(br, contentLength);
+        return HttpRequestParser.parseKeyValuePairs(body);
+    }
+
+    private static String readBodyContent(BufferedReader br, String contentLength) throws IOException {
+        StringBuilder bodyBuffer = new StringBuilder();
+        int length = Integer.parseInt(contentLength);
+        for (int i = 0; i < length; i++) {
+            bodyBuffer.append((char) br.read());
+        }
+        return bodyBuffer.toString();
+    }
+
+    private static Map<String, String> readHeader(BufferedReader br) throws IOException {
+        StringBuilder headerBuffer = new StringBuilder();
+        String line;
+        while (!(line = br.readLine()).isEmpty()) {
+            headerBuffer.append(line);
+        }
+        return HttpRequestParser.parseKeyValuePairs(headerBuffer.toString());
     }
 
     public void log() {
@@ -67,5 +89,9 @@ public class HttpRequest {
     private String getRequestTarget() {
         String[] split = startLine.split(BLANK);
         return split[1];
+    }
+
+    public Map<String, String> getBody() {
+        return body;
     }
 }

--- a/src/main/java/webserver/httpMessage/HttpRequest.java
+++ b/src/main/java/webserver/httpMessage/HttpRequest.java
@@ -8,6 +8,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.HashMap;
 import java.util.Map;
 
 public class HttpRequest {
@@ -17,6 +18,7 @@ public class HttpRequest {
     public static final String BLANK = " ";
     public static final String REQUEST_TARGET_DELIMITER = "?";
     public static final String CONTENT_LENGTH = "Content-Length";
+    public static final String HEADER_DELIMITER = ":?\\s";
 
     private final String startLine;
     private final String requestTarget;
@@ -58,12 +60,13 @@ public class HttpRequest {
     }
 
     private static Map<String, String> readHeader(BufferedReader br) throws IOException {
-        StringBuilder headerBuffer = new StringBuilder();
+        Map<String, String> header = new HashMap<>();
         String line;
         while (!(line = br.readLine()).isEmpty()) {
-            headerBuffer.append(line);
+            String[] split = line.split(HEADER_DELIMITER);
+            header.put(split[0], split[1]);
         }
-        return HttpRequestParser.parseKeyValuePairs(headerBuffer.toString());
+        return header;
     }
 
     public void log() {

--- a/src/main/java/webserver/httpMessage/HttpResponse.java
+++ b/src/main/java/webserver/httpMessage/HttpResponse.java
@@ -67,7 +67,7 @@ public class HttpResponse {
     private static List<String> getRedirectHeader(String location) {
         List<String> header = new ArrayList<>();
 
-        header.add(HttpStatus.TEMPORARY_REDIRECTION.getStatusMessage());
+        header.add(HttpStatus.SEE_OTHER.getStatusMessage());
         header.add("Location: " + location + " \r\n");
         header.add("\r\n");
 

--- a/src/main/java/webserver/httpMessage/HttpStatus.java
+++ b/src/main/java/webserver/httpMessage/HttpStatus.java
@@ -2,7 +2,8 @@ package webserver.httpMessage;
 
 public enum HttpStatus {
     OK("HTTP/1.1 200 OK \r\n"),
-    TEMPORARY_REDIRECTION("HTTP/1.1 307 Temporary Redirect \r\n");
+    TEMPORARY_REDIRECTION("HTTP/1.1 307 Temporary Redirect \r\n"),
+    SEE_OTHER("HTTP/1.1 303 See Other \r\n");
 
     private final String statusMessage;
 

--- a/src/main/java/webserver/utils/HttpRequestParser.java
+++ b/src/main/java/webserver/utils/HttpRequestParser.java
@@ -5,21 +5,21 @@ import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.Map;
 
-public class Parser {
+public class HttpRequestParser {
 
     public static final String UTF_8 = "UTF-8";
     public static final String QUERY_DELIMITER = "&";
     public static final String KEY_VALUE_DELIMITER = "=";
 
-    public static Map<String, String> splitQuery(String query) throws UnsupportedEncodingException {
-        Map<String, String> query_pairs = new HashMap<>();
+    public static Map<String, String> parseKeyValuePairs(String query) throws UnsupportedEncodingException {
+        Map<String, String> queryPairs = new HashMap<>();
         String[] pairs = query.split(QUERY_DELIMITER);
 
         for (String pair : pairs) {
             String[] split = pair.split(KEY_VALUE_DELIMITER);
-            query_pairs.put(URLDecoder.decode(split[0], UTF_8), URLDecoder.decode(split[1], UTF_8));
+            queryPairs.put(URLDecoder.decode(split[0], UTF_8), URLDecoder.decode(split[1], UTF_8));
         }
 
-        return query_pairs;
+        return queryPairs;
     }
 }

--- a/src/main/resources/static/registration/index.html
+++ b/src/main/resources/static/registration/index.html
@@ -23,7 +23,7 @@
       </header>
       <div class="page">
         <h2 class="page-title">회원가입</h2>
-        <form class="form" action="/create" method="get">
+        <form class="form" action="/create" method="post">
           <div class="textfield textfield_size_s">
             <p class="title_textfield">아이디</p>
             <input

--- a/src/test/java/webserver/httpMessage/HttpRequestTest.java
+++ b/src/test/java/webserver/httpMessage/HttpRequestTest.java
@@ -3,7 +3,7 @@ package webserver.httpMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
+import java.util.HashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -13,7 +13,7 @@ class HttpRequestTest {
 
     @BeforeEach
     void init() {
-        httpRequest = new HttpRequest(List.of("GET /create?userId=cori&password=1234&name=cori&email=cori@naver.com HTTP/1.1 \r\n"));
+        httpRequest = new HttpRequest("GET /create?userId=cori&password=1234&name=cori&email=cori@naver.com HTTP/1.1 \r\n", new HashMap<>(), new HashMap<>());
     }
 
     @Test

--- a/src/test/java/webserver/utils/HttpRequestParserTest.java
+++ b/src/test/java/webserver/utils/HttpRequestParserTest.java
@@ -7,12 +7,12 @@ import org.junit.jupiter.api.Test;
 import java.io.UnsupportedEncodingException;
 import java.util.Map;
 
-class ParserTest {
+class HttpRequestParserTest {
     @Test
     @DisplayName("쿼리 파라미터를 Map으로 변환")
     void parseQueryParams() throws UnsupportedEncodingException {
         String query = "userId=cori123&password=1234&name=cori&email=cori%40naver.com";
-        Map<String, String> userForm = Parser.splitQuery(query);
+        Map<String, String> userForm = HttpRequestParser.parseKeyValuePairs(query);
 
         Map<String, String> expected = Map.of(
                 "userId", "cori123",


### PR DESCRIPTION
## 구현 내용
- POST 회원가입 구현
- 회원가입 성공시 `303` 상태 코드를 설정해 홈 화면으로 리다이렉트
  - step-3에서 `307` 상태 코드로 리다이렉트 하도록 작성한 걸 `303 See Other`로 변경
- HTTP 요청 헤더와 바디를 `Map`으로 저장
  - 회원 가입 시 유저 정보가 HTTP 요청 body에 들어오면, key-value 로 저장


## 고민 사항
- HTTP 요청의 body가 비어있을 경우 처리
HTTP 요청의 바디가 없을 경우 빈 `Map`을 리턴하는 로직을 작성하던 중 `contentLength == null`과 `return Map.of()` 부분이 어색하게 느껴집니다.  
```java
private static Map<String, String> readBody(BufferedReader br, String contentLength) throws IOException {
        if (contentLength == null) {
            return Map.of();
        }

        String body = readBodyContent(br, contentLength);
        return Parser.parseKeyValuePairs(body);
    }
```

- 리소스 파일 경로
현재는 리소스 파일에 접근할 때 경로를 다음과 같이 상수로 정의하고 있습니다.  
`private static final String STATIC_PATH = "src/main/resources/static"`
경로를 상수로 정의해두면 실행 환경에 따라 문제가 생길 수 있다고 하는데, 실제로도 상수로 경로를 정의해두는 방법은 잘 사용하지 않는지 궁금합니다.

## 실행 결과
### 회원가입
<img width="590" alt="스크린샷 2024-03-18 오후 7 14 47" src="https://github.com/codesquad-members-2024/be-was-neon/assets/110909423/6cef2e8b-8a88-4511-86b2-0a4ed094edf7">  

### 유저 정보 저장
<img width="566" alt="스크린샷 2024-03-18 오후 7 23 46" src="https://github.com/codesquad-members-2024/be-was-neon/assets/110909423/74e460e3-c7b3-46c4-bb36-8acae6ee01c2">  

### 홈 화면으로 리다이렉션
<img width="196" alt="스크린샷 2024-03-18 오후 7 14 57" src="https://github.com/codesquad-members-2024/be-was-neon/assets/110909423/68889b99-48ed-4b99-9e4e-25f4d2ca9f01">


