### PR TITLE
[yelly] step-4 POST로 회원 가입

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,35 @@
 - 학습 내용 정리: [WAS1 - Wiki](https://github.com/Yeriimii/be-was-neon/wiki/Java-Concurrent-%E2%80%90-CompletableFuture)
 
 # 전체 요청 흐름
+```mermaid
+---
+title: 요청 흐름도 
+---
+flowchart LR
+    subgraph RequestHandler
+        direction LR
+        subgraph convert
+            direction TB
+            HttpHeaderParser --Header 정보--> HttpConverter
+            HttpConverter --파싱 요청--> HttpHeaderParser
+        end
+        subgraph mapping
+            UriMapper
+        end
+        subgraph process
+            direction TB
+            ResourceHandler --byte array--> HttpProcessor
+            HttpProcessor --static file path--> ResourceHandler
+        end
+        HttpRequest
+        HttpResponse
+    end
+WebServer --Socket--> RequestHandler
+HttpConverter --> HttpRequest
+HttpConverter --> HttpResponse
+HttpRequest --URI--> UriMapper --> HttpProcessor --write--> HttpResponse --> Client
+```
+
 ## HTTP GET 요청 흐름 (`/index.html`, `/registration`)
 ```mermaid
 sequenceDiagram

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ sequenceDiagram
 ## HttpRequestConverter
 - [x] Socket의 connection으로부터 requestString을 한 줄로 만들 수 있다
 - [x] 한 줄의 requestString으로부터 HttpRequest 객체로 컨버팅 할 수 있다
+- [x] http 요청에 body가 있을 경우 body 내용을 쿼리 파라미터로 가져올 수 있다
 
 ## HttpResponseConverter
 - [x] Socket의 connection으로부터 HttpResponse를 생성할 수 있다

--- a/src/main/java/http/HttpRequest.java
+++ b/src/main/java/http/HttpRequest.java
@@ -6,39 +6,15 @@ public class HttpRequest {
     private final HttpMethod method;
     private final String requestURI;
     private final String httpVersion;
-    private final String host;
-    private final String userAgent;
-    private final String accept;
-    private final String acceptLanguage;
-    private final String acceptEncoding;
-    private final String referer;
-    private final String connection;
-    private final String ifModifiedSince;
-    private final String ifNoneMatch;
-    private final String cacheControl;
-    private final String cookie;
-    private final String pragma;
+    private final Map<String, String> headers;
     private final Map<String, String> parameter;
 
-    protected HttpRequest(HttpMethod method, String requestURI, String httpVersion, String host, String userAgent,
-                       String accept, String acceptLanguage, String acceptEncoding, String referer, String connection,
-                       String ifModifiedSince, String ifNoneMatch, String cacheControl, String cookie, String pragma,
-                          Map<String, String> parameter) {
+    protected HttpRequest(HttpMethod method, String requestURI, String httpVersion,
+                          Map<String, String> headers, Map<String, String> parameter) {
         this.method = method;
         this.requestURI = requestURI;
         this.httpVersion = httpVersion;
-        this.host = host;
-        this.userAgent = userAgent;
-        this.accept = accept;
-        this.acceptLanguage = acceptLanguage;
-        this.acceptEncoding = acceptEncoding;
-        this.referer = referer;
-        this.connection = connection;
-        this.ifModifiedSince = ifModifiedSince;
-        this.ifNoneMatch = ifNoneMatch;
-        this.cacheControl = cacheControl;
-        this.cookie = cookie;
-        this.pragma = pragma;
+        this.headers = headers;
         this.parameter = parameter;
     }
 
@@ -54,52 +30,8 @@ public class HttpRequest {
         return httpVersion;
     }
 
-    public String getHost() {
-        return host;
-    }
-
-    public String getUserAgent() {
-        return userAgent;
-    }
-
-    public String getAccept() {
-        return accept;
-    }
-
-    public String getAcceptLanguage() {
-        return acceptLanguage;
-    }
-
-    public String getAcceptEncoding() {
-        return acceptEncoding;
-    }
-
-    public String getReferer() {
-        return referer;
-    }
-
-    public String getConnection() {
-        return connection;
-    }
-
-    public String getIfModifiedSince() {
-        return ifModifiedSince;
-    }
-
-    public String getIfNoneMatch() {
-        return ifNoneMatch;
-    }
-
-    public String getCacheControl() {
-        return cacheControl;
-    }
-
-    public String getCookie() {
-        return cookie;
-    }
-
-    public String getPragma() {
-        return pragma;
+    public String getHeader(String headerName) {
+        return headers.getOrDefault(headerName, "");
     }
 
     public String getParameter(String parameterName) {

--- a/src/main/java/http/HttpRequestBuilder.java
+++ b/src/main/java/http/HttpRequestBuilder.java
@@ -7,24 +7,12 @@ public class HttpRequestBuilder {
     private HttpMethod method;
     private String requestURI = "";
     private String httpVersion = "";
-    private String host = "";
-    private String userAgent = "";
-    private String accept = "";
-    private String acceptLanguage = "";
-    private String acceptEncoding = "";
-    private String referer = "";
-    private String connection = "";
-    private String ifModifiedSince = "";
-    private String ifNoneMatch = "";
-    private String cacheControl = "";
-    private String cookie = "";
-    private String pragma = "";
+    private Map<String, String> headers = new HashMap<>();
     private Map<String, String> parameter = new HashMap<>();
 
     public HttpRequest build() {
         return new HttpRequest(
-                method, requestURI, httpVersion, host, userAgent, accept, acceptLanguage, acceptEncoding,
-                referer, connection, ifModifiedSince, ifNoneMatch, cacheControl, cookie, pragma, parameter
+                method, requestURI, httpVersion, headers, parameter
         );
     }
 
@@ -43,63 +31,8 @@ public class HttpRequestBuilder {
         return this;
     }
 
-    public HttpRequestBuilder setHost(String host) {
-        this.host = host;
-        return this;
-    }
-
-    public HttpRequestBuilder setUserAgent(String userAgent) {
-        this.userAgent = userAgent;
-        return this;
-    }
-
-    public HttpRequestBuilder setAccept(String accept) {
-        this.accept = accept;
-        return this;
-    }
-
-    public HttpRequestBuilder setAcceptLanguage(String acceptLanguage) {
-        this.acceptLanguage = acceptLanguage;
-        return this;
-    }
-
-    public HttpRequestBuilder setAcceptEncoding(String acceptEncoding) {
-        this.acceptEncoding = acceptEncoding;
-        return this;
-    }
-
-    public HttpRequestBuilder setReferer(String referer) {
-        this.referer = referer;
-        return this;
-    }
-
-    public HttpRequestBuilder setConnection(String connection) {
-        this.connection = connection;
-        return this;
-    }
-
-    public HttpRequestBuilder setIfModifiedSince(String ifModifiedSince) {
-        this.ifModifiedSince = ifModifiedSince;
-        return this;
-    }
-
-    public HttpRequestBuilder setIfNoneMatch(String ifNoneMatch) {
-        this.ifNoneMatch = ifNoneMatch;
-        return this;
-    }
-
-    public HttpRequestBuilder setCacheControl(String cacheControl) {
-        this.cacheControl = cacheControl;
-        return this;
-    }
-
-    public HttpRequestBuilder setCookie(String cookie) {
-        this.cookie = cookie;
-        return this;
-    }
-
-    public HttpRequestBuilder setPragma(String pragma) {
-        this.pragma = pragma;
+    public HttpRequestBuilder setHeaders(Map<String, String> headers) {
+        this.headers = headers;
         return this;
     }
 

--- a/src/main/java/http/HttpResponse.java
+++ b/src/main/java/http/HttpResponse.java
@@ -18,6 +18,7 @@ public class HttpResponse {
     private String contentLength = "Content-Length: ";
     private String lastModified = "Last-Modified: ";
     private String setCookie = "Set-Cookie: ";
+    private String location = "Location: ";
     private final DataOutputStream dos;
 
     public HttpResponse(DataOutputStream dos) {
@@ -63,6 +64,12 @@ public class HttpResponse {
         return this;
     }
 
+    public HttpResponse setLocation(String location) {
+        this.location += location;
+        writeString(this.location + CRLF);
+        return this;
+    }
+
     public HttpResponse setMessageBody(String stringMessageBody) {
         writeString(CRLF);
         writeString(stringMessageBody + CRLF);
@@ -83,6 +90,7 @@ public class HttpResponse {
             logger.error("[RESPONSE ERROR] flush error: {}", e.getMessage());
         }
     }
+
     private void writeString(String string) {
         try {
             dos.writeBytes(string);

--- a/src/main/java/http/HttpStatus.java
+++ b/src/main/java/http/HttpStatus.java
@@ -4,6 +4,7 @@ public enum HttpStatus {
     STATUS_OK(200, "OK"),
     STATUS_CREATED(201, "Created"),
     STATUS_MOVED_PERMANENTLY(301, "Moved Permanently"),
+    STATUS_FOUND(302, "Found"),
     STATUS_FORBIDDEN(403, "Forbidden"),
     STATUS_NOT_FOUND(404, "Not Found"),
     STATUS_NOT_ALLOWED(405, "Method Not Allowed"),

--- a/src/main/java/utils/HttpHeaderParser.java
+++ b/src/main/java/utils/HttpHeaderParser.java
@@ -19,7 +19,8 @@ public enum HttpHeaderParser {
     CACHE_CONTROL(Pattern.compile("Cache-Control:.*")),
     COOKIE(Pattern.compile("Cookie:.*")),
     PRAGMA(Pattern.compile("Pragma:.*")),
-    QUERY_PARAMETER(Pattern.compile("[?&]([^=]+)=([^&]+)")),
+    CONTENT_LENGTH(Pattern.compile("Content-Length:.*")),
+    QUERY_PARAMETER(Pattern.compile("([^?&=\\s]+)=([^&\\s]+)")),
     OTHER(Pattern.compile(".*:.*")),
     ;
 

--- a/src/main/java/utils/HttpHeaderParser.java
+++ b/src/main/java/utils/HttpHeaderParser.java
@@ -7,21 +7,8 @@ import java.util.regex.Pattern;
 
 public enum HttpHeaderParser {
     REQUEST_LINE(Pattern.compile("(^GET|^POST) (/.*) (HTTP/.{1,3})")),
-    HOST(Pattern.compile("Host:.*")),
-    USER_AGENT(Pattern.compile("User-Agent:.*")),
-    ACCEPT(Pattern.compile("Accept:.*")),
-    ACCEPT_LANGUAGE(Pattern.compile("Accept-Language:.*")),
-    ACCEPT_ENCODING(Pattern.compile("Accept-Encoding:.*")),
-    REFERER(Pattern.compile("Referer:.*")),
-    CONNECTION(Pattern.compile("Connection:.*")),
-    IF_MODIFIED_SINCE(Pattern.compile("If-Modified-Since:.*")),
-    IF_NONE_MATCH(Pattern.compile("If-None-Match:.*")),
-    CACHE_CONTROL(Pattern.compile("Cache-Control:.*")),
-    COOKIE(Pattern.compile("Cookie:.*")),
-    PRAGMA(Pattern.compile("Pragma:.*")),
-    CONTENT_LENGTH(Pattern.compile("Content-Length:.*")),
+    HEADERS(Pattern.compile("([^:\\s]+):\\s?(.+)\\s")),
     QUERY_PARAMETER(Pattern.compile("([^?&=\\s]+)=([^&\\s]+)")),
-    OTHER(Pattern.compile(".*:.*")),
     ;
 
     private final Pattern compiledPattern;
@@ -30,12 +17,22 @@ public enum HttpHeaderParser {
         this.compiledPattern = compiledPattern;
     }
 
-    public String parse(String header) {
-        Matcher headerMatcher = compiledPattern.matcher(header);
-        if (headerMatcher.find()) {
-            return headerMatcher.group();
+    public static String parseRequestLine(String header) {
+        Matcher requestLineMatcher = REQUEST_LINE.compiledPattern.matcher(header);
+        if (requestLineMatcher.find()) {
+            return requestLineMatcher.group();
         }
         return "";
+    }
+
+    public static Map<String, String> parseHeader(String header) {
+        Map<String, String> headers = new HashMap<>();
+
+        Matcher headerMatcher = HEADERS.compiledPattern.matcher(header);
+        while (headerMatcher.find()) {
+            headers.put(headerMatcher.group(1), headerMatcher.group(2));
+        }
+        return headers;
     }
 
     public static Map<String, String> parseParams(String header) {

--- a/src/main/java/utils/HttpRequestConverter.java
+++ b/src/main/java/utils/HttpRequestConverter.java
@@ -57,7 +57,7 @@ public class HttpRequestConverter {
     private static int calculateContentLength(String line) {
         int contentLength = 0;
 
-        if (CONTENT_LENGTH.parse(line).isEmpty()) {
+        if (!line.startsWith("Content-Length")) {
             return contentLength;
         }
 
@@ -86,37 +86,8 @@ public class HttpRequestConverter {
         builder.setRequestURI(requestURI);
         builder.setHttpVersion(httpVersion);
 
-        /* Host */
-        builder.setHost(HOST.parse(header));
-
-        /* User-Agent */
-        builder.setUserAgent(USER_AGENT.parse(header));
-
-        /* Connection */
-        builder.setConnection(CONNECTION.parse(header));
-
-        /* Accept */
-        builder.setAccept(ACCEPT.parse(header));
-
-        /* Accept-Encoding */
-        builder.setAcceptEncoding(ACCEPT_ENCODING.parse(header));
-
-        /* Accept-Language */
-        builder.setAcceptLanguage(ACCEPT_LANGUAGE.parse(header));
-
-        /* Referer */
-        builder.setReferer(REFERER.parse(header));
-
-        /* If-Modified-Since */
-        builder.setIfModifiedSince(IF_MODIFIED_SINCE.parse(header));
-
-        /* If-None-Match */
-        builder.setIfNoneMatch(IF_NONE_MATCH.parse(header));
-
-        /* Cache-Control */
-        builder.setCacheControl(CACHE_CONTROL.parse(header));
-        builder.setCookie(COOKIE.parse(header));
-        builder.setPragma(PRAGMA.parse(header));
+        /* headers */
+        builder.setHeaders(parseHeader(header));
 
         /* parameter */
         if (method == HttpMethod.GET) {
@@ -130,7 +101,7 @@ public class HttpRequestConverter {
     }
 
     private static String[] splitRequestLine(String header) {
-        return REQUEST_LINE.parse(header).split(BLANK); // 'GET /registration?id=test&password=1234 HTTP/1.1'
+        return parseRequestLine(header).split(BLANK); // 'GET /registration?id=test&password=1234 HTTP/1.1'
     }
 
     private static HttpMethod getMethod(String[] requestLine) {

--- a/src/main/java/web/HtmlProcessor.java
+++ b/src/main/java/web/HtmlProcessor.java
@@ -30,18 +30,18 @@ public class HtmlProcessor extends HttpProcessor {
     }
 
     public void responseHeader200(HttpResponse response, String contentType) {
-        response.setHttpVersion("HTTP/1.1")
+        response.setHttpVersion(BASIC_HTTP_VERSION)
                 .setStatusCode(HttpStatus.STATUS_OK)
                 .setContentType(contentType)
-                .setCharset("utf-8");
+                .setCharset(BASIC_CHAR_SET);
     }
 
     public void responseHeader302(HttpResponse response, String contentType, String location) {
-        response.setHttpVersion("HTTP/1.1")
+        response.setHttpVersion(BASIC_HTTP_VERSION)
                 .setStatusCode(HttpStatus.STATUS_FOUND)
                 .setLocation(location)
                 .setContentType(contentType)
-                .setCharset("utf-8");
+                .setCharset(BASIC_CHAR_SET);
     }
 
     public void responseMessage(HttpResponse response, byte[] resource) {

--- a/src/main/java/web/HtmlProcessor.java
+++ b/src/main/java/web/HtmlProcessor.java
@@ -36,13 +36,24 @@ public class HtmlProcessor extends HttpProcessor {
                 .setCharset("utf-8");
     }
 
-    private void responseMessage(HttpResponse response, byte[] resource) {
+    public void responseHeader302(HttpResponse response, String contentType, String location) {
+        response.setHttpVersion("HTTP/1.1")
+                .setStatusCode(HttpStatus.STATUS_FOUND)
+                .setLocation(location)
+                .setContentType(contentType)
+                .setCharset("utf-8");
+    }
+
     public void responseMessage(HttpResponse response, byte[] resource) {
         response.setContentLength(resource.length)
                 .setMessageBody(resource);
     }
 
-    private String getContentType(HttpRequest request) {
+    public void responseMessage(HttpResponse response, String message) {
+        response.setContentLength(message.length())
+                .setMessageBody(message);
+    }
+
     public String getContentType(HttpRequest request) {
         String extension = getExtension(request.getRequestURI());
         return FILE_EXTENSION_MAP.getOrDefault(extension, "text/html");

--- a/src/main/java/web/HtmlProcessor.java
+++ b/src/main/java/web/HtmlProcessor.java
@@ -29,7 +29,7 @@ public class HtmlProcessor extends HttpProcessor {
         return read(RESOURCE_PATH + request.getRequestURI() + "/" + INDEX_HTML); // /registration
     }
 
-    private void responseHeader200(HttpResponse response, String contentType) {
+    public void responseHeader200(HttpResponse response, String contentType) {
         response.setHttpVersion("HTTP/1.1")
                 .setStatusCode(HttpStatus.STATUS_OK)
                 .setContentType(contentType)
@@ -37,11 +37,13 @@ public class HtmlProcessor extends HttpProcessor {
     }
 
     private void responseMessage(HttpResponse response, byte[] resource) {
+    public void responseMessage(HttpResponse response, byte[] resource) {
         response.setContentLength(resource.length)
                 .setMessageBody(resource);
     }
 
     private String getContentType(HttpRequest request) {
+    public String getContentType(HttpRequest request) {
         String extension = getExtension(request.getRequestURI());
         return FILE_EXTENSION_MAP.getOrDefault(extension, "text/html");
     }

--- a/src/main/java/web/HttpProcessor.java
+++ b/src/main/java/web/HttpProcessor.java
@@ -4,6 +4,8 @@ import http.HttpRequest;
 import http.HttpResponse;
 
 public abstract class HttpProcessor {
+    public static final String BASIC_HTTP_VERSION = "HTTP/1.1";
+    public static final String BASIC_CHAR_SET = "utf-8";
 
     abstract void process(HttpRequest request, HttpResponse response);
 

--- a/src/main/java/web/MemberSave.java
+++ b/src/main/java/web/MemberSave.java
@@ -1,5 +1,7 @@
 package web;
 
+import static http.HttpMethod.POST;
+
 import db.Database;
 import http.HttpRequest;
 import http.HttpResponse;
@@ -9,16 +11,20 @@ public class MemberSave extends HtmlProcessor {
 
     @Override
     public void process(HttpRequest request, HttpResponse response) {
-        if (request.getParameter("id").isEmpty()) {
-            super.process(request, response);
+        if (request.getMethod() == POST) {
+            String id = request.getParameter("id");
+            String username = request.getParameter("username");
+            String email = request.getParameter("email");
+            String password = request.getParameter("password");
+
+            Database.addUser(new User(id, password, username, email));
+
+            responseHeader302(response, getContentType(request), "/index.html");
+            responseMessage(response, "ok");
+
+            response.flush();
             return;
         }
-        String id = request.getParameter("id");
-        String username = request.getParameter("username");
-        String email = request.getParameter("email");
-        String password = request.getParameter("password");
-
-        Database.addUser(new User(id, password, username, email));
         super.process(request, response);
     }
 }

--- a/src/main/java/web/MemberSave.java
+++ b/src/main/java/web/MemberSave.java
@@ -12,12 +12,7 @@ public class MemberSave extends HtmlProcessor {
     @Override
     public void process(HttpRequest request, HttpResponse response) {
         if (request.getMethod() == POST) {
-            String id = request.getParameter("id");
-            String username = request.getParameter("username");
-            String email = request.getParameter("email");
-            String password = request.getParameter("password");
-
-            Database.addUser(new User(id, password, username, email));
+            Database.addUser(createUser(request));
 
             responseHeader302(response, getContentType(request), "/index.html");
             responseMessage(response, "ok");
@@ -26,5 +21,14 @@ public class MemberSave extends HtmlProcessor {
             return;
         }
         super.process(request, response);
+    }
+
+    private User createUser(HttpRequest request) {
+        String id = request.getParameter("id");
+        String username = request.getParameter("username");
+        String email = request.getParameter("email");
+        String password = request.getParameter("password");
+
+        return new User(id, password, username, email);
     }
 }

--- a/src/main/resources/static/registration/index.html
+++ b/src/main/resources/static/registration/index.html
@@ -23,7 +23,7 @@
     </header>
     <div class="page">
         <h2 class="page-title">회원가입</h2>
-        <form class="form" action="" method="get">
+        <form class="form" action="" method="post">
             <div class="textfield textfield_size_s">
                 <p class="title_textfield">아이디</p>
                 <input

--- a/src/test/java/http/HttpResponseTest.java
+++ b/src/test/java/http/HttpResponseTest.java
@@ -31,6 +31,7 @@ class HttpResponseTest {
                 .setContentType("text/html")
                 .setCharset("utf-8")
                 .setContentLength(100)
+                .setLocation("/myLocation.html")
                 .setSetCookie("myCookie=myValue")
                 .setLastModified(
                         LocalDateTime.parse(
@@ -44,6 +45,7 @@ class HttpResponseTest {
                         HTTP/1.1 200 OK\r
                         Content-Type: text/html; charset=utf-8\r
                         Content-Length: 100\r
+                        Location: /myLocation.html\r
                         Set-Cookie: myCookie=myValue;\r
                         Last-Modified: 2024-03-13T13:00:12\r
                         \r

--- a/src/test/java/utils/HttpHeaderParserTest.java
+++ b/src/test/java/utils/HttpHeaderParserTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.*;
 import static utils.HttpHeaderParser.*;
 
 import java.util.Map;
-import java.util.Map.Entry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -17,176 +16,10 @@ class HttpHeaderParserTest {
         String requestHeader = "GET /home.html HTTP/1.1\nHost: developer.mozilla.org";
 
         // when
-        String requestLine = REQUEST_LINE.parse(requestHeader);
+        String requestLine = parseRequestLine(requestHeader);
 
         // then
         assertThat(requestLine).isEqualTo("GET /home.html HTTP/1.1");
-    }
-
-    @DisplayName("\"GET /home.html HTTP/1.1\nHost: developer.mozilla.org\"를 파싱하면 host를 추출할 수 있다.")
-    @Test
-    void parse_host() {
-        // given
-        String requestHeader = "GET /home.html HTTP/1.1\nHost: developer.mozilla.org";
-
-        // when
-        String requestLine = HOST.parse(requestHeader);
-
-        // then
-        assertThat(requestLine).isEqualTo("Host: developer.mozilla.org");
-    }
-
-    @DisplayName("\"Host: developer.mozilla.org\nUser-Agent: Mozilla/5.0 Macintosh Firefox/50.0\"를 파싱하면 user-agent를 추출할 수 있다.")
-    @Test
-    void parse_user_agent() {
-        // given
-        String requestHeader = "Host: developer.mozilla.org\nUser-Agent: Mozilla/5.0 Macintosh Firefox/50.0";
-
-        // when
-        String requestLine = USER_AGENT.parse(requestHeader);
-
-        // then
-        assertThat(requestLine).isEqualTo("User-Agent: Mozilla/5.0 Macintosh Firefox/50.0");
-    }
-
-    @DisplayName("\"Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\nAccept-Language: en-US,en;q=0.5\"를 파싱하면 기본 accept를 추출할 수 있다.")
-    @Test
-    void parse_accept() {
-        // given
-        String requestHeader = "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\nAccept-Language: en-US,en;q=0.5";
-
-        // when
-        String requestLine = ACCEPT.parse(requestHeader);
-
-        // then
-        assertThat(requestLine).isEqualTo("Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
-    }
-
-    @DisplayName("\"Accept-Language: en-US,en;q=0.5\nAccept-Encoding: gzip, deflate, br\"를 파싱하면 accept-language를 추출할 수 있다.")
-    @Test
-    void parse_accept_language() {
-        // given
-        String requestHeader = "Accept-Language: en-US,en;q=0.5\nAccept-Encoding: gzip, deflate, br";
-
-        // when
-        String requestLine = ACCEPT_LANGUAGE.parse(requestHeader);
-
-        // then
-        assertThat(requestLine).isEqualTo("Accept-Language: en-US,en;q=0.5");
-    }
-
-    @DisplayName("\"Accept-Language: en-US,en;q=0.5\nAccept-Encoding: gzip, deflate, br\"를 파싱하면 accept-encoding을 추출할 수 있다.")
-    @Test
-    void parse_accept_encoding() {
-        // given
-        String requestHeader = "Accept-Language: en-US,en;q=0.5\nAccept-Encoding: gzip, deflate, br";
-
-        // when
-        String requestLine = ACCEPT_ENCODING.parse(requestHeader);
-
-        // then
-        assertThat(requestLine).isEqualTo("Accept-Encoding: gzip, deflate, br");
-    }
-
-    @DisplayName("\"Referer: https://developer.mozilla.org/testpage.html\nConnection: keep-alive\"를 파싱하면 referer를 추출할 수 있다.")
-    @Test
-    void parse_referer() {
-        // given
-        String requestHeader = "Referer: https://developer.mozilla.org/testpage.html\nConnection: keep-alive";
-
-        // when
-        String requestLine = REFERER.parse(requestHeader);
-
-        // then
-        assertThat(requestLine).isEqualTo("Referer: https://developer.mozilla.org/testpage.html");
-    }
-
-    @DisplayName("\"Referer: https://developer.mozilla.org/testpage.html\nConnection: keep-alive\"를 파싱하면 connection을 추출할 수 있다.")
-    @Test
-    void parse_connection() {
-        // given
-        String requestHeader = "Referer: https://developer.mozilla.org/testpage.html\nConnection: keep-alive";
-
-        // when
-        String requestLine = CONNECTION.parse(requestHeader);
-
-        // then
-        assertThat(requestLine).isEqualTo("Connection: keep-alive");
-    }
-
-    @DisplayName("\"If-Modified-Since: Mon, 18 Jul 2016 02:36:04 GMT\nIf-None-Match: \"c561c68d0ba92bbeb8b0fff2a9199f722e3a621a\"\"를 파싱하면 if_modified_since을 추출할 수 있다.")
-    @Test
-    void parse_if_modified_since() {
-        // given
-        String requestHeader = "If-Modified-Since: Mon, 18 Jul 2016 02:36:04 GMT\nIf-None-Match: \"c561c68d0ba92bbeb8b0fff2a9199f722e3a621a\"";
-
-        // when
-        String requestLine = IF_MODIFIED_SINCE.parse(requestHeader);
-
-        // then
-        assertThat(requestLine).isEqualTo("If-Modified-Since: Mon, 18 Jul 2016 02:36:04 GMT");
-    }
-
-    @DisplayName("\"If-Modified-Since: Mon, 18 Jul 2016 02:36:04 GMT\nIf-None-Match: \"c561c68d0ba92bbeb8b0fff2a9199f722e3a621a\"\"를 파싱하면 if_none_match를 추출할 수 있다.")
-    @Test
-    void parse_if_none_match() {
-        // given
-        String requestHeader = "If-Modified-Since: Mon, 18 Jul 2016 02:36:04 GMT\nIf-None-Match: \"c561c68d0ba92bbeb8b0fff2a9199f722e3a621a\"";
-
-        // when
-        String requestLine = IF_NONE_MATCH.parse(requestHeader);
-
-        // then
-        assertThat(requestLine).isEqualTo("If-None-Match: \"c561c68d0ba92bbeb8b0fff2a9199f722e3a621a\"");
-    }
-
-    @DisplayName("\"If-None-Match: \"c561c68d0ba92bbeb8b0fff2a9199f722e3a621a\"\nCache-Control: max-age=0\"를 파싱하면 cache_control을 추출할 수 있다.")
-    @Test
-    void parse_cache_control() {
-        // given
-        String requestHeader = "If-None-Match: \"c561c68d0ba92bbeb8b0fff2a9199f722e3a621a\"\nCache-Control: max-age=0";
-
-        // when
-        String requestLine = CACHE_CONTROL.parse(requestHeader);
-
-        // then
-        assertThat(requestLine).isEqualTo("Cache-Control: max-age=0");
-    }
-
-    @DisplayName("\"Cache-Control: max-age=0\nCookie: _ga=GA1.1.1443472205.1698820297;\"를 파싱하면 cookie 추출할 수 있다.")
-    @Test
-    void parse_cookie() {
-        // given
-        String requestHeader = "Cache-Control: max-age=0\nCookie: _ga=GA1.1.1443472205.1698820297;";
-        // when
-        String requestLine = COOKIE.parse(requestHeader);
-
-        // then
-        assertThat(requestLine).isEqualTo("Cookie: _ga=GA1.1.1443472205.1698820297;");
-    }
-    @DisplayName("\"Cache-Control: max-age=0\nPragma: no-cache\"를 파싱하면 pragma 추출할 수 있다.")
-    @Test
-    void parse_pragma() {
-        // given
-        String requestHeader = "Cache-Control: max-age=0\nPragma: no-cache";
-        // when
-        String requestLine = PRAGMA.parse(requestHeader);
-
-        // then
-        assertThat(requestLine).isEqualTo("Pragma: no-cache");
-    }
-
-    @DisplayName("\"\\*:\\*\" 형태의 헤더를 파싱하면 헤더를 그대로 추출할 수 있다.")
-    @Test
-    void parse_other() {
-        // given
-        String requestHeader = "아무거나: 아무거나 어쩌구";
-
-        // when
-        String requestLine = OTHER.parse(requestHeader);
-
-        // then
-        assertThat(requestLine).isEqualTo("아무거나: 아무거나 어쩌구");
     }
 
     @DisplayName("'/index.html?name=str&id=str2&money=123'에서 쿼리파라미터를 추출하면 name=str, id=str2, money=123 3개 이다")
@@ -204,5 +37,56 @@ class HttpHeaderParserTest {
                 .containsEntry("id", "str2")
                 .containsEntry("money", "123");
         assertThat(params).doesNotContainEntry("noKey", "noValue");
+    }
+
+    @DisplayName("'GET /home.html?name=str&id=str2&money=123 HTTP/1.1\nHost: developer.mozilla.org\nCache-Control: max-age=0\nPragma: no-cache'를 파싱하면 host를 추출할 수 있다.")
+    @Test
+    void parse_all_headers() {
+        // given
+        String headers = """
+                GET /index.html?test1=test1&test2=test2 HTTP/1.1
+                Host: localhost:8080
+                Connection: keep-alive
+                Pragma: no-cache
+                Cache-Control: no-cache
+                sec-ch-ua: "Chromium";v="122", "Not(A:Brand";v="24", "Google Chrome";v="122"
+                sec-ch-ua-mobile: ?0
+                sec-ch-ua-platform: "macOS"
+                Upgrade-Insecure-Requests: 1
+                User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36
+                Accept: text/html,application/xhtml xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7
+                Sec-Fetch-Site: same-origin
+                Sec-Fetch-Mode: navigate
+                Sec-Fetch-User: ?1
+                Sec-Fetch-Dest: document
+                Referer: http://localhost:8080/
+                Accept-Encoding: gzip, deflate, br, zstd
+                Accept-Language: ko,en-US;q=0.9,en;q=0.8,ko-KR;q=0.7
+                Cookie: Idea-fcd223d4=b6a3f2fa-6bf3-46d9-9244-dc44850cb75f; JSESSIONID=98B78C0DDB07A7320453FE9FB565C7F3; Idea-fcd223d5=56a54692-c173-433b-b8a0-65b80db19507
+                """;
+
+        // then
+        Map<String, String> headerMap = parseHeader(headers);
+
+        // then
+        assertThat(headerMap.size()).isEqualTo(18);
+        assertThat(headerMap).containsEntry("Host", "localhost:8080");
+        assertThat(headerMap).containsEntry("Connection", "keep-alive");
+        assertThat(headerMap).containsEntry("Pragma", "no-cache");
+        assertThat(headerMap).containsEntry("Cache-Control", "no-cache");
+        assertThat(headerMap).containsEntry("sec-ch-ua", "\"Chromium\";v=\"122\", \"Not(A:Brand\";v=\"24\", \"Google Chrome\";v=\"122\"");
+        assertThat(headerMap).containsEntry("sec-ch-ua-mobile", "?0");
+        assertThat(headerMap).containsEntry("sec-ch-ua-platform", "\"macOS\"");
+        assertThat(headerMap).containsEntry("Upgrade-Insecure-Requests", "1");
+        assertThat(headerMap).containsEntry("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36");
+        assertThat(headerMap).containsEntry("Accept", "text/html,application/xhtml xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7");
+        assertThat(headerMap).containsEntry("Sec-Fetch-Site", "same-origin");
+        assertThat(headerMap).containsEntry("Sec-Fetch-Mode", "navigate");
+        assertThat(headerMap).containsEntry("Sec-Fetch-User", "?1");
+        assertThat(headerMap).containsEntry("Sec-Fetch-Dest", "document");
+        assertThat(headerMap).containsEntry("Referer", "http://localhost:8080/");
+        assertThat(headerMap).containsEntry("Accept-Encoding", "gzip, deflate, br, zstd");
+        assertThat(headerMap).containsEntry("Accept-Language", "ko,en-US;q=0.9,en;q=0.8,ko-KR;q=0.7");
+        assertThat(headerMap).containsEntry("Cookie", "Idea-fcd223d4=b6a3f2fa-6bf3-46d9-9244-dc44850cb75f; JSESSIONID=98B78C0DDB07A7320453FE9FB565C7F3; Idea-fcd223d5=56a54692-c173-433b-b8a0-65b80db19507");
     }
 }

--- a/src/test/java/utils/HttpRequestConverterTest.java
+++ b/src/test/java/utils/HttpRequestConverterTest.java
@@ -38,20 +38,20 @@ class HttpRequestConverterTest {
         assertThat(httpRequest.getHttpVersion()).isEqualTo("HTTP/1.1");
 
         /* headers */
-        assertThat(httpRequest.getHost()).isEqualTo("Host: localhost:8080");
-        assertThat(httpRequest.getConnection()).isEqualTo("Connection: keep-alive");
-        assertThat(httpRequest.getReferer()).isEqualTo("Referer: \"https://www.google.com/\"");
-        assertThat(httpRequest.getUserAgent()).isEqualTo("User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36");
+        assertThat(httpRequest.getHeader("Host")).isEqualTo("localhost:8080");
+        assertThat(httpRequest.getHeader("Connection")).isEqualTo("keep-alive");
+        assertThat(httpRequest.getHeader("Referer")).isEqualTo("\"https://www.google.com/\"");
+        assertThat(httpRequest.getHeader("User-Agent")).isEqualTo("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36");
 
-        assertThat(httpRequest.getAccept()).isEqualTo("Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7");
-        assertThat(httpRequest.getAcceptEncoding()).isEqualTo("Accept-Encoding: gzip, deflate, br, zstd");
-        assertThat(httpRequest.getAcceptLanguage()).isEqualTo("Accept-Language: ko,en-US;q=0.9,en;q=0.8,ko-KR;q=0.7");
+        assertThat(httpRequest.getHeader("Accept")).isEqualTo("text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7");
+        assertThat(httpRequest.getHeader("Accept-Encoding")).isEqualTo("gzip, deflate, br, zstd");
+        assertThat(httpRequest.getHeader("Accept-Language")).isEqualTo("ko,en-US;q=0.9,en;q=0.8,ko-KR;q=0.7");
 
-        assertThat(httpRequest.getCookie()).isEqualTo("Cookie: Idea-fcd223d4=b6a3f2fa-6bf3-46d9-9244-dc44850cb75f;");
-        assertThat(httpRequest.getCacheControl()).isEqualTo("Cache-Control: no-cache");
-        assertThat(httpRequest.getPragma()).isEqualTo("Pragma: no-cache");
-        assertThat(httpRequest.getIfModifiedSince()).isEqualTo("If-Modified-Since: none;");
-        assertThat(httpRequest.getIfNoneMatch()).isEqualTo("If-None-Match: none;");
+        assertThat(httpRequest.getHeader("Cookie")).isEqualTo("Idea-fcd223d4=b6a3f2fa-6bf3-46d9-9244-dc44850cb75f;");
+        assertThat(httpRequest.getHeader("Cache-Control")).isEqualTo("no-cache");
+        assertThat(httpRequest.getHeader("Pragma")).isEqualTo("no-cache");
+        assertThat(httpRequest.getHeader("If-Modified-Since")).isEqualTo("none;");
+        assertThat(httpRequest.getHeader("If-None-Match")).isEqualTo("none;");
     }
 
     @DisplayName("post 요청일 때 http body인 'id=yelly&password=myPassword&username=testName&email=test@test.com'를 쿼리 파라미터로 가져올 수 있다")

--- a/src/test/java/utils/HttpRequestConverterTest.java
+++ b/src/test/java/utils/HttpRequestConverterTest.java
@@ -53,4 +53,24 @@ class HttpRequestConverterTest {
         assertThat(httpRequest.getIfModifiedSince()).isEqualTo("If-Modified-Since: none;");
         assertThat(httpRequest.getIfNoneMatch()).isEqualTo("If-None-Match: none;");
     }
+
+    @DisplayName("post 요청일 때 http body인 'id=yelly&password=myPassword&username=testName&email=test@test.com'를 쿼리 파라미터로 가져올 수 있다")
+    @Test
+    void post_convert() {
+        // given
+        String header = """
+                POST /registration HTTP/1.1
+                Host: localhost:8080
+                Content-Length: 66
+                id=yelly&password=myPassword&username=testName&email=test@test.com""";
+
+        // when
+        HttpRequest httpRequest = HttpRequestConverter.convert(header);
+
+        // then
+        assertThat(httpRequest.getParameter("id")).isEqualTo("yelly");
+        assertThat(httpRequest.getParameter("password")).isEqualTo("myPassword");
+        assertThat(httpRequest.getParameter("username")).isEqualTo("testName");
+        assertThat(httpRequest.getParameter("email")).isEqualTo("test@test.com");
+    }
 }


### PR DESCRIPTION
## 구현 내용
- 회원가입 시 GET 요청에서 POST 요청으로 변경했습니다
- 회원가입 후 `/index.html` 로 리다이렉트를 구현했습니다
  - HTTP Status Code를 302 Found로, Response Header 부분에 `Location` 지정을 통해 구현했습니다

## 고민 사항
- 현재 HTTP Request를 처리하는 방식이 request header와 request body를 하나로 합친 후, 합친 전체 문자열을 지정한 정규표현식으로 파싱하고 있습니다.
- 이 부분을 더 적은 코드로 고치기 위해, HttpRequest 내에 있는 많은 헤더 필드들을 Map으로 갖는 방식으로 전환하는 것을 고려하고 있습니다.
- Processor 객체가 request 처리 로직에 따라 response를 유연하게 작성할 수 있도록 돕는 response 작성용 유틸 클래스를 만드는 것을 고려하고 있습니다.