### PR TITLE
[제이든] 웹 서버 4단계 - POST로 회원 가입

### DIFF
--- a/src/main/java/webserver/IndexManager.java
+++ b/src/main/java/webserver/IndexManager.java
@@ -9,7 +9,7 @@ import webserver.response.HttpResponseHeader;
 import webserver.response.HttpResponseStatusLine;
 import webserver.response.HttpStatus;
 import webserver.response.HttpVersion;
-import webserver.utils.ReadingFiles;
+import webserver.utils.HttpMessageUtils;
 
 public class IndexManager {
 
@@ -22,7 +22,7 @@ public class IndexManager {
         if (file.isDirectory()) {
             file = new File(sourceRelativePath + requestURI + "/" + "index.html");
         }
-        byte[] body = ReadingFiles.readByteFromFile(file);
+        byte[] body = HttpMessageUtils.readByteFromFile(file);
 
         HttpResponseStatusLine httpResponseStatusLine = new HttpResponseStatusLine(
             HttpVersion.HTTP11, HttpStatus.OK);

--- a/src/main/java/webserver/request/HttpRequest.java
+++ b/src/main/java/webserver/request/HttpRequest.java
@@ -10,16 +10,21 @@ public class HttpRequest {
     private static final Logger logger = LoggerFactory.getLogger(HttpRequest.class);
     private final HttpRequestStartLine httpRequestStartLine;
     private final HttpRequestHeader httpRequestHeader;
+    private HttpRequestBody httpRequestBody;
+    private static final String CRLF = "\r\n";
 
     public HttpRequest(BufferedReader httpRequest) throws IOException {
         httpRequestStartLine = new HttpRequestStartLine(readRequestLine(httpRequest));
         httpRequestHeader = new HttpRequestHeader(readHeaderLine(httpRequest));
+//        if (httpRequestStartLine.getMethod().equals("POST")) {
+//            httpRequestBody = new HttpRequestBody(readBodyLine(httpRequest));
+//        }
     }
 
     private String readRequestLine(BufferedReader httpRequest) throws IOException {
         StringBuilder requestBuilder = new StringBuilder();
         String line;
-        if ((line = httpRequest.readLine()) != null && !line.isEmpty()) {
+        if ((line = httpRequest.readLine()) != null && line != CRLF) {
             requestBuilder.append(line).append('\n');
             logger.debug("Request Line: {}", line);
         }
@@ -31,12 +36,22 @@ public class HttpRequest {
         StringBuilder requestHeaderBuilder = new StringBuilder();
         String line;
 
-        while ((line = httpRequest.readLine()) != null && !line.isEmpty()) {
+        while (!(line = httpRequest.readLine()).isEmpty()) {
             requestHeaderBuilder.append(line).append('\n');
             logger.debug("Header Line: {}", line);
         }
         return requestHeaderBuilder.toString();
     }
+
+    private String readBodyLine(BufferedReader httpRequest, int contentLength) throws IOException {
+        StringBuilder requestBodyBuilder = new StringBuilder();
+
+        char[] buffer = new char[contentLength];
+        int bytesRead = httpRequest.read(buffer, 0, contentLength);
+        requestBodyBuilder.append(buffer, 0, bytesRead);
+        return requestBodyBuilder.toString();
+    }
+
 
     public HttpRequestStartLine getHttpRequestStartLine() {
         return httpRequestStartLine;

--- a/src/main/java/webserver/request/HttpRequest.java
+++ b/src/main/java/webserver/request/HttpRequest.java
@@ -11,21 +11,23 @@ public class HttpRequest {
     private final HttpRequestStartLine httpRequestStartLine;
     private final HttpRequestHeader httpRequestHeader;
     private HttpRequestBody httpRequestBody;
-    private static final String CRLF = "\r\n";
+    private static final String LF = "\n";
 
     public HttpRequest(BufferedReader httpRequest) throws IOException {
         httpRequestStartLine = new HttpRequestStartLine(readRequestLine(httpRequest));
         httpRequestHeader = new HttpRequestHeader(readHeaderLine(httpRequest));
-//        if (httpRequestStartLine.getMethod().equals("POST")) {
-//            httpRequestBody = new HttpRequestBody(readBodyLine(httpRequest));
-//        }
+        if (httpRequestStartLine.getMethod().equals("POST")) {
+            int contentLength = Integer.parseInt(
+                httpRequestHeader.getHeaders().get("Content-Length"));
+            httpRequestBody = new HttpRequestBody(readBodyLine(httpRequest, contentLength));
+        }
     }
 
     private String readRequestLine(BufferedReader httpRequest) throws IOException {
         StringBuilder requestBuilder = new StringBuilder();
         String line;
-        if ((line = httpRequest.readLine()) != null && line != CRLF) {
-            requestBuilder.append(line).append('\n');
+        if ((line = httpRequest.readLine()) != null && line != LF) {
+            requestBuilder.append(line).append(LF);
             logger.debug("Request Line: {}", line);
         }
 
@@ -37,7 +39,7 @@ public class HttpRequest {
         String line;
 
         while (!(line = httpRequest.readLine()).isEmpty()) {
-            requestHeaderBuilder.append(line).append('\n');
+            requestHeaderBuilder.append(line).append(LF);
             logger.debug("Header Line: {}", line);
         }
         return requestHeaderBuilder.toString();
@@ -49,6 +51,7 @@ public class HttpRequest {
         char[] buffer = new char[contentLength];
         int bytesRead = httpRequest.read(buffer, 0, contentLength);
         requestBodyBuilder.append(buffer, 0, bytesRead);
+        logger.debug("Body Line: {}", requestBodyBuilder);
         return requestBodyBuilder.toString();
     }
 

--- a/src/main/java/webserver/request/HttpRequest.java
+++ b/src/main/java/webserver/request/HttpRequest.java
@@ -63,4 +63,8 @@ public class HttpRequest {
     public HttpRequestHeader getHttpRequestHeader() {
         return httpRequestHeader;
     }
+
+    public HttpRequestBody getHttpRequestBody() {
+        return httpRequestBody;
+    }
 }

--- a/src/main/java/webserver/request/HttpRequestBody.java
+++ b/src/main/java/webserver/request/HttpRequestBody.java
@@ -1,0 +1,11 @@
+package webserver.request;
+
+public class HttpRequestBody {
+
+    private String bodyMessage;
+
+    public HttpRequestBody(String bodyMessage) {
+        this.bodyMessage = bodyMessage;
+    }
+
+}

--- a/src/main/java/webserver/request/HttpRequestBody.java
+++ b/src/main/java/webserver/request/HttpRequestBody.java
@@ -8,4 +8,7 @@ public class HttpRequestBody {
         this.bodyMessage = bodyMessage;
     }
 
+    public String getBodyMessage() {
+        return bodyMessage;
+    }
 }

--- a/src/main/java/webserver/request/HttpRequestHeader.java
+++ b/src/main/java/webserver/request/HttpRequestHeader.java
@@ -1,10 +1,35 @@
 package webserver.request;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 public class HttpRequestHeader {
 
-    private String headerMessage;
+    private static final String CRLF = "\r\n";
 
-    public HttpRequestHeader(String headerMessage) {
-        this.headerMessage = headerMessage;
+
+    private final Map<String, String> requestHeader;
+
+    public HttpRequestHeader(String headersInput) {
+        this.requestHeader = new HashMap<>();
+        parseHeader(headersInput);
     }
+
+    private void parseHeader(String headersInput) {
+        String[] headers = headersInput.split(CRLF);
+        for (String header : headers) {
+            String[] keyValue = header.split(":", 2);
+            requestHeader.put(keyValue[0].trim(), keyValue[1].trim());
+        }
+    }
+
+    public Map<String, String> getHeaders() {
+        return Collections.unmodifiableMap(requestHeader);
+    }
+
+    public String getValue(String key) {
+        return getHeaders().get(key);
+    }
+
 }

--- a/src/main/java/webserver/request/HttpRequestHeader.java
+++ b/src/main/java/webserver/request/HttpRequestHeader.java
@@ -1,23 +1,23 @@
 package webserver.request;
 
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class HttpRequestHeader {
 
-    private static final String CRLF = "\r\n";
+    private static final String LF = "\n";
 
 
     private final Map<String, String> requestHeader;
 
     public HttpRequestHeader(String headersInput) {
-        this.requestHeader = new HashMap<>();
+        this.requestHeader = new LinkedHashMap<>();
         parseHeader(headersInput);
     }
 
     private void parseHeader(String headersInput) {
-        String[] headers = headersInput.split(CRLF);
+        String[] headers = headersInput.split(LF);
         for (String header : headers) {
             String[] keyValue = header.split(":", 2);
             requestHeader.put(keyValue[0].trim(), keyValue[1].trim());

--- a/src/main/java/webserver/request/HttpRequestStartLine.java
+++ b/src/main/java/webserver/request/HttpRequestStartLine.java
@@ -1,17 +1,11 @@
 package webserver.request;
 
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 public class HttpRequestStartLine {
 
     private final String method;
     private String requestURI;
 
-    private Map<String, String> queries = new HashMap<>();
+    private String queryString;
 
     public HttpRequestStartLine(String requestLine) {
         String[] requestLines = requestLine.split(" ");
@@ -38,31 +32,11 @@ public class HttpRequestStartLine {
     private void extractQueryFromURI(String URI) {
         String[] URIs = URI.split("\\?");
         requestURI = URIs[0];
-        queries = parseQueryString(URIs[1]);
+        queryString = URIs[1];
     }
 
-    private Map<String, String> parseQueryString(String string) {
-        Map<String, String> queryMap = new HashMap<>();
-
-        String[] pairs = string.split("&");
-
-        for (String pair : pairs) {
-
-            String[] keyValue = pair.split("=");
-
-            String key = keyValue[0];
-            String value = URLDecoder.decode(keyValue[1], StandardCharsets.UTF_8);
-
-            queryMap.put(key, value);
-        }
-        return queryMap;
+    public String getQueryString() {
+        return queryString;
     }
 
-    public Map<String, String> getQueries() {
-        return Collections.unmodifiableMap(queries);
-    }
-
-    public String getValue(String key) {
-        return getQueries().get(key);
-    }
 }

--- a/src/main/java/webserver/utils/HttpMessageUtils.java
+++ b/src/main/java/webserver/utils/HttpMessageUtils.java
@@ -4,8 +4,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
-public class ReadingFiles {
+public class HttpMessageUtils {
 
     public static byte[] readByteFromFile(File file) {
         try (FileInputStream fileInputStream = new FileInputStream(file);) {
@@ -17,6 +20,21 @@ public class ReadingFiles {
             return byteArrayOutputStream.toByteArray();
         } catch (IOException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    public static void parseQueryString(String bodyMessage, Map<String, String> queryMap) {
+
+        String[] pairs = bodyMessage.split("&");
+
+        for (String pair : pairs) {
+
+            String[] keyValue = pair.split("=");
+
+            String key = keyValue[0];
+            String value = URLDecoder.decode(keyValue[1], StandardCharsets.UTF_8);
+
+            queryMap.put(key, value);
         }
     }
 

--- a/src/main/resources/static/registration/index.html
+++ b/src/main/resources/static/registration/index.html
@@ -23,7 +23,7 @@
   </header>
   <div class="page">
     <h2 class="page-title">회원가입</h2>
-    <form id="registration-form" class="form" action="/create" method="GET">
+    <form id="registration-form" class="form" action="/create" method="POST">
       <div class="textfield textfield_size_s">
         <p class="title_textfield">아이디</p>
         <input

--- a/src/test/java/webserver/HttpMessageHandlerTest.java
+++ b/src/test/java/webserver/HttpMessageHandlerTest.java
@@ -8,7 +8,7 @@ import java.nio.file.Files;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import webserver.request.HttpRequestStartLine;
-import webserver.utils.ReadingFiles;
+import webserver.utils.HttpMessageUtils;
 
 class HttpMessageHandlerTest {
 
@@ -33,7 +33,7 @@ class HttpMessageHandlerTest {
 
         HttpMessageHandler httpMessageHandler = new HttpMessageHandler(null);
 
-        byte[] actualBytes = ReadingFiles.readByteFromFile(file);
+        byte[] actualBytes = HttpMessageUtils.readByteFromFile(file);
 
         byte[] expectedBytes = Files.readAllBytes(file.toPath());
 

--- a/src/test/java/webserver/RegisterManagerTest.java
+++ b/src/test/java/webserver/RegisterManagerTest.java
@@ -1,0 +1,87 @@
+package webserver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import model.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import webserver.request.HttpRequest;
+import webserver.response.HttpResponse;
+
+class RegisterManagerTest {
+
+    private HttpRequest getHttpRequest;
+    private HttpRequest postHttpRequest;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        String getHttpRequestString =
+            "GET /create?userId=jayden&nickname=%EC%A0%9C%EC%9D%B4%EB%93%A0&password=1234 HTTP/1.1\n"
+                +
+                "Host: localhost:8080\n" +
+                "Connection: keep-alive\n" +
+                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8\n"
+                +
+                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.71 Safari/537.36\n"
+                +
+                "Accept-Encoding: gzip, deflate, br\n" +
+                "Accept-Language: en-US,en;q=0.9\n" +
+                "\n";
+
+        String postHttpRequestString =
+            "POST /create HTTP/1.1\n" +
+                "Host: localhost:8080\n" +
+                "Connection: keep-alive\n" +
+                "Content-Type: application/x-www-form-urlencoded\n" +
+                "Content-Length: 64\n" + // 바디 길이 설정
+                "\n" +
+                "userId=jayden&nickname=%EC%A0%9C%EC%9D%B4%EB%93%A0&password=1234"; // POST 요청 바디
+
+        BufferedReader getReader = new BufferedReader(new StringReader(getHttpRequestString));
+        BufferedReader postReader = new BufferedReader(new StringReader(postHttpRequestString));
+        getHttpRequest = new HttpRequest(getReader);
+        postHttpRequest = new HttpRequest(postReader);
+    }
+
+    @Test
+    @DisplayName("GET 요청일 때 userId 정보가 Register Manager에 잘 저장되는지 확인하는 테스트")
+    void getUserIdFromGetRequest() {
+        HttpResponse httpResponse = RegisterManager.registerResponse(getHttpRequest);
+        assertThat(RegisterManager.getRegisterInformation().get("userId")).isEqualTo("jayden");
+    }
+
+    @Test
+    @DisplayName("GET 요청일 때 nickName 정보가 Register Manager에 잘 저장되는지 확인하는 테스트")
+    void getNicknameFromGetRequest() {
+        HttpResponse httpResponse = RegisterManager.registerResponse(getHttpRequest);
+        assertThat(RegisterManager.getRegisterInformation().get("nickname")).isEqualTo("제이든");
+    }
+
+    @Test
+    @DisplayName("POST 요청일 때 nickName 정보가 Register Manager에 잘 저장되는지 확인하는 테스트")
+    void getUserIdFromPostRequest() {
+        HttpResponse httpResponse = RegisterManager.registerResponse(postHttpRequest);
+        assertThat(RegisterManager.getRegisterInformation().get("userId")).isEqualTo("jayden");
+    }
+
+    @Test
+    @DisplayName("GET 요청일 때 nickName 정보가 Register Manager에 잘 저장되는지 확인하는 테스트")
+    void getNicknameFromPostRequest() {
+        HttpResponse httpResponse = RegisterManager.registerResponse(postHttpRequest);
+        assertThat(RegisterManager.getRegisterInformation().get("nickname")).isEqualTo("제이든");
+    }
+
+    @Test
+    @DisplayName("회원가입 Request를보내고 User 객체가 잘 만들어지는지 테스트")
+    void testCreateUserFromQueryParms() {
+        HttpResponse httpResponse = RegisterManager.registerResponse(postHttpRequest);
+        User user = new User(RegisterManager.getRegisterInformation().get("userId"),
+            RegisterManager.getRegisterInformation().get("nickname"),
+            RegisterManager.getRegisterInformation().get("password"));
+        assertThat(user.getUserId()).isEqualTo("jayden");
+    }
+}

--- a/src/test/java/webserver/request/HttpRequestHeaderTest.java
+++ b/src/test/java/webserver/request/HttpRequestHeaderTest.java
@@ -1,0 +1,44 @@
+package webserver.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class HttpRequestHeaderTest {
+
+    private HttpRequestHeader httpRequestHeader;
+
+    @BeforeEach
+    void setUp() {
+        httpRequestHeader = new HttpRequestHeader("Host: localhost:8080\r\n"
+            + "Connection: keep-alive\r\n"
+            + "Accept: */*\r\n"
+            + "User-Agent: Mozilla/5.0\r\n"
+            + "Accept-Encoding: gzip, deflate, br\r\n"
+            + "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7\r\n"
+            + "Cookie: _gat_gtag_UA_123456789_1=1\r\n"
+            + "Content-Length: 0\r\n"
+            + "\r\n");
+    }
+
+
+    @Test
+    @DisplayName("header를 파싱하고 key값이 8개가 저장되었는지 확인하는 테스트")
+    void parseHeaderAndVerifyKeysCount() {
+        assertThat(httpRequestHeader.getHeaders().keySet().size()).isEqualTo(8);
+    }
+
+    @Test
+    @DisplayName("header를 파싱하고 value가 총 8개가 저장되었는지 확인하는 테스트")
+    void parseHeaderAndVerifyValuesCount() {
+        assertThat(httpRequestHeader.getHeaders().values().size()).isEqualTo(8);
+    }
+
+    @Test
+    @DisplayName("header를 파싱하고 Content-Length에 0 value가 저장되었는지 테스트")
+    void parseContentLength() {
+        assertThat(httpRequestHeader.getValue("Content-Length")).isEqualTo("0");
+    }
+}

--- a/src/test/java/webserver/request/HttpRequestStartLineTest.java
+++ b/src/test/java/webserver/request/HttpRequestStartLineTest.java
@@ -2,13 +2,9 @@ package webserver.request;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Map;
-import model.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 
 class HttpRequestStartLineTest {
 
@@ -39,25 +35,5 @@ class HttpRequestStartLineTest {
         assertThat(httpRequestStartLine.getRequestURI()).isEqualTo("/create");
     }
 
-
-    @ParameterizedTest
-    @CsvSource({"userId, jayden", "nickname, 제이든", "password, 1234"})
-    @DisplayName("query parameter가 있을 때 query를 파싱하는 테스트")
-    void extractQueryFromURI(String key, String value) {
-        httpRequestStartLine = new HttpRequestStartLine(
-            "GET /create?userId=jayden&nickname=%EC%A0%9C%EC%9D%B4%EB%93%A0&password=1234 HTTP/1.1");
-        Map<String, String> queries = httpRequestStartLine.getQueries();
-        assertThat(queries.get(key)).isEqualTo(value);
-    }
-
-    @Test
-    @DisplayName("HttpRequest객체로부터 파라미터를 불러와서 User 객체가 잘 만들어지는지 테스트")
-    void testCreateUserFromQueryParms() {
-        httpRequestStartLine = new HttpRequestStartLine(
-            "GET /create?userId=jayden&nickname=%EC%A0%9C%EC%9D%B4%EB%93%A0&password=1234 HTTP/1.1");
-        User user = new User(httpRequestStartLine.getValue("userId"),
-            httpRequestStartLine.getValue("nickName"), httpRequestStartLine.getValue("password"));
-        assertThat(user.getUserId()).isEqualTo("jayden");
-    }
 }
 

--- a/src/test/java/webserver/response/HttpResponseStatusLineTest.java
+++ b/src/test/java/webserver/response/HttpResponseStatusLineTest.java
@@ -15,7 +15,7 @@ class HttpResponseStatusLineTest {
             HttpVersion.HTTP11, HttpStatus.OK);
 
         assertThat(httpResponseStatusLine.getHttpStatusLineMessage()).isEqualTo(
-            "HTTP/1.1 202 OK");
+            "HTTP/1.1 200 OK");
 
     }
 }


### PR DESCRIPTION
## 구현 내용

- 기존에 query를 파싱하던 기능을 startline에서 진행하지 않고 stringutils 클래스에서 진행하도록 변경.
- post 메서드가 추가됨에 따라서 register manager가 get과 post에 따라서 파싱을 다르게함.
- HttpRequestHeader를 LinkedHashMap으로 저장.
- HttpRequestBody를 읽을 때는 content length에 대한 정보를 받고 해당 count만큼 읽도록 함.

## 고민한점
- HttpRequest의 body를 읽을 때 어떤 식으로 구현할 지 생각을 많이 했습니다. http request message의 body의 마지막을 처리하기 위해서 (EOF을..) content-length의 길이만큼만 char를 읽도록 구현함.
- content length에 대한 정보는 request header에 존재하고 response header와 같이 linkedhashmap으로 관리함.
- 공통적으로 사용하는 utils 메서드는 stringutils라는 클래스에 모아서 관리하는게 좋다고 판단했습니다. (특정 클래스에서만 사용하는 것이 아니게 때문에)
