### PR TITLE
[코리] step-5 쿠키를 이용한 로그인

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,41 +23,45 @@
     - `307 Temporary Redirect`는 `308`과 달리 리다이렉트 요청이 캐싱되지 않는다.
 
 ## 구현 내용
+### STEP 1
 - Thread 대신 ExecutorService 를 사용하도록 리팩토링
 - HTTP Request 내용 출력
-- 파일 형식에 따라 HTTP Response Header 의 content-type을 변경
 - 요청 타켓이 디렉토리면 해당 디렉토리의 `index.html` 파일을 반환하도록 구현
 - RequestHandler의 run 메서드의 코드를 HttpRequest, HttpResponse 클래스로 분할
+
+
+### STEP 2
+- 파일 형식에 따라 HTTP Response Header 의 content-type을 변경
+
+
+### STEP 3
 - 회원 가입 기능 구현
   - 쿼리 파라미터를 파싱해 `Map`으로 저장하는 로직 추가
-  - 유저 정보가 들어있는 `Map` 객체를 받아 `User` 객체를 반환하는 정적 팩토리 메서드 구현  
-  - 회원 가입 시 로그인 페이지로 리다이렉션
+  - 유저 정보가 들어있는 `Map` 객체를 받아 `User` 객체를 반환하는 정적 팩토리 메서드 구현
+- 회원 가입 시 로그인 페이지로 리다이렉션
 - 테스트 코드 작성
+
+
+### STEP 4
 - POST 회원가입 구현
-- 회원가입 성공 시 홈 화면으로 리다이렉션  
+- 회원가입 성공 시 홈 화면으로 리다이렉션
+- GET 핸들러와 POST 핸들러 분할
+
+
+### STEP 5
+- URI 별 동작을 정의해둔 `Handler` 구현체를 각각 정의
+  - URI에 따라 `HttpResponse`를 반환하는 메서드를 클래스 단위로 리팩터링
+- 로그인 기능 구현
+  - 로그인 성공
+    - 쿠키에 세션 아이디 추가
+    - `SessionManager`에 `SessionId, User`를 key-value로 추가
+    - `index.html`로 리다이렉트
+  - 로그인 실패
+    - `/login/login_failed.html`로 리다이렉트
+
 
 ## 요청 타겟 별 기능
 - `/` : `index.html` 을 반환
-- `/login` : `login/index.html` 반환
+- `/login` : 로그인을 시도하고 `/index.html`, `/login/login-failed.html` 중 하나를 반환
 - `/registration` : `registration/index.html`
 - `/create` : 쿼리 파라미터의 값으로 User 객체를 만들어 저장 후 로그인 페이지로 리다이렉트
-
-
-## 고민사항
-- HTTP 요청의 body가 비어있을 경우 처리
-HTTP 요청의 바디가 없을 경우 빈 `Map`을 리턴하는 로직을 작성하던 중 `contentLength == null`과 `return Map.of()` 부분이 어색하게 느껴집니다.  
-```java
-private static Map<String, String> readBody(BufferedReader br, String contentLength) throws IOException {
-        if (contentLength == null) {
-            return Map.of();
-        }
-
-        String body = readBodyContent(br, contentLength);
-        return Parser.parseKeyValuePairs(body);
-    }
-```
-
-- 리소스 파일 경로
-현재는 리소스 파일에 접근할 때 경로를 다음과 같이 상수로 정의하고 있습니다.  
-`private static final String STATIC_PATH = "src/main/resources/static"`
-경로를 상수로 정의해두면 실행 환경에 따라 문제가 생길 수 있다고 하는데, 실제로도 상수로 경로를 정의해두는 방법은 잘 사용하지 않는지 궁금합니다.

--- a/src/main/java/model/User.java
+++ b/src/main/java/model/User.java
@@ -39,4 +39,8 @@ public class User {
     public String toString() {
         return "User [userId=" + userId + ", password=" + password + ", name=" + name + ", email=" + email + "]";
     }
+
+    public boolean verifyPassword(String password) {
+        return this.password.equals(password);
+    }
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -3,6 +3,7 @@ package webserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import webserver.httpMessage.HttpRequest;
+import webserver.httpMessage.HttpRequestReader;
 import webserver.httpMessage.HttpResponse;
 
 import java.io.IOException;
@@ -25,7 +26,8 @@ public class RequestHandler implements Runnable {
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
-            HttpRequest httpRequest = HttpRequest.from(in);
+            HttpRequestReader reader = new HttpRequestReader(in);
+            HttpRequest httpRequest = reader.readHttpRequest();
             httpRequest.log();
 
             HttpResponse httpResponse = RequestMapper.service(httpRequest);

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -2,6 +2,7 @@ package webserver;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import webserver.handler.Handler;
 import webserver.httpMessage.HttpRequest;
 import webserver.httpMessage.HttpRequestReader;
 import webserver.httpMessage.HttpResponse;
@@ -28,9 +29,10 @@ public class RequestHandler implements Runnable {
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
             HttpRequestReader reader = new HttpRequestReader(in);
             HttpRequest httpRequest = reader.readHttpRequest();
-            httpRequest.log();
 
-            HttpResponse httpResponse = RequestMapper.service(httpRequest);
+            Handler handler = RequestMapper.findHandler(httpRequest);
+
+            HttpResponse httpResponse = handler.service(httpRequest);
             httpResponse.send(out);
         } catch (IOException e) {
             logger.error(e.getMessage());

--- a/src/main/java/webserver/RequestMapper.java
+++ b/src/main/java/webserver/RequestMapper.java
@@ -1,67 +1,21 @@
 package webserver;
 
-import db.Database;
-import model.User;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import webserver.handler.*;
 import webserver.httpMessage.HttpRequest;
-import webserver.httpMessage.HttpResponse;
-import webserver.utils.HttpRequestParser;
 
-import java.io.File;
 import java.util.Map;
-import java.util.function.Function;
 
 public class RequestMapper {
 
-    private static final Logger logger = LoggerFactory.getLogger(RequestMapper.class);
-
-    private static final String STATIC_PATH = "src/main/resources/static";
-    private static final String INDEX_HTML = "/index.html";
-    public static final String REGISTRATION = "/registration";
-    public static final String LOGIN = "/login";
-
-    private static final Map<String, Function<HttpRequest, HttpResponse>> map = Map.ofEntries(
-            Map.entry("/", RequestMapper::home),
-            Map.entry("/registration", RequestMapper::register),
-            Map.entry("/login", RequestMapper::login),
-            Map.entry("/create", RequestMapper::createUser)
+    private static final Map<String, Handler> map = Map.ofEntries(
+            Map.entry("/", new HomeHandler()),
+            Map.entry("/registration", new RegistrationHandler()),
+            Map.entry("/create", new UserCreateHandler())
     );
+    private static final StaticFileHandler fileHandler = new StaticFileHandler();
 
-    public static HttpResponse service(HttpRequest request) {
+    public static Handler findHandler(HttpRequest request) {
         String uri = request.getUri();
-        if (map.containsKey(uri)) {
-            return map.get(uri).apply(request);
-        }
-        return getStaticFileResponse(uri);
-    }
-
-    private static HttpResponse getStaticFileResponse(String uri) {
-        return HttpResponse.from(new File(STATIC_PATH + uri));
-    }
-
-    private static HttpResponse home(HttpRequest request) {
-        File file = new File(STATIC_PATH + INDEX_HTML);
-        return HttpResponse.from(file);
-    }
-
-    private static HttpResponse register(HttpRequest request) {
-        File file = new File(STATIC_PATH + REGISTRATION + INDEX_HTML);
-        return HttpResponse.from(file);
-    }
-
-    private static HttpResponse login(HttpRequest request) {
-        File file = new File(STATIC_PATH + LOGIN + INDEX_HTML);
-        return HttpResponse.from(file);
-    }
-
-    private static HttpResponse createUser(HttpRequest request) {
-        String body = request.getBody();
-        Map<String, String> userForm = HttpRequestParser.parseKeyValuePairs(body);
-
-        User user = User.from(userForm);
-        Database.addUser(user);
-        logger.debug("User created : {}", Database.findUserById(user.getUserId()));
-        return HttpResponse.redirect(INDEX_HTML);
+        return map.getOrDefault(uri, fileHandler);
     }
 }

--- a/src/main/java/webserver/RequestMapper.java
+++ b/src/main/java/webserver/RequestMapper.java
@@ -10,7 +10,8 @@ public class RequestMapper {
     private static final Map<String, Handler> map = Map.ofEntries(
             Map.entry("/", new HomeHandler()),
             Map.entry("/registration", new RegistrationHandler()),
-            Map.entry("/create", new UserCreateHandler())
+            Map.entry("/create", new UserCreateHandler()),
+            Map.entry("/login", new LoginHandler())
     );
     private static final StaticFileHandler fileHandler = new StaticFileHandler();
 

--- a/src/main/java/webserver/RequestMapper.java
+++ b/src/main/java/webserver/RequestMapper.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import webserver.httpMessage.HttpRequest;
 import webserver.httpMessage.HttpResponse;
+import webserver.utils.HttpRequestParser;
 
 import java.io.File;
 import java.util.Map;
@@ -55,7 +56,8 @@ public class RequestMapper {
     }
 
     private static HttpResponse createUser(HttpRequest request) {
-        Map<String, String> userForm = request.getBody();
+        String body = request.getBody();
+        Map<String, String> userForm = HttpRequestParser.parseKeyValuePairs(body);
 
         User user = User.from(userForm);
         Database.addUser(user);

--- a/src/main/java/webserver/Session/SessionManger.java
+++ b/src/main/java/webserver/Session/SessionManger.java
@@ -1,0 +1,24 @@
+package webserver.Session;
+
+import model.User;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SessionManger {
+
+    private static final Map<String, User> loginUsers = new HashMap<>();
+
+    public static User getUser(String sid) {
+        return loginUsers.get(sid);
+    }
+
+    public static boolean isLogin(String sid) {
+        return loginUsers.containsKey(sid);
+    }
+
+    public static void addLoginUser(String sid, User user) {
+        loginUsers.put(sid, user);
+    }
+
+}

--- a/src/main/java/webserver/handler/Handler.java
+++ b/src/main/java/webserver/handler/Handler.java
@@ -1,0 +1,8 @@
+package webserver.handler;
+
+import webserver.httpMessage.HttpRequest;
+import webserver.httpMessage.HttpResponse;
+
+public interface Handler {
+    HttpResponse service(HttpRequest request);
+}

--- a/src/main/java/webserver/handler/HomeHandler.java
+++ b/src/main/java/webserver/handler/HomeHandler.java
@@ -2,6 +2,7 @@ package webserver.handler;
 
 import webserver.httpMessage.HttpRequest;
 import webserver.httpMessage.HttpResponse;
+import webserver.httpMessage.HttpStatus;
 
 import java.io.File;
 
@@ -13,6 +14,10 @@ public class HomeHandler implements Handler {
     @Override
     public HttpResponse service(HttpRequest request) {
         File file = new File(HOME_PAGE.getRelativePath());
-        return HttpResponse.from(file);
+
+        HttpResponse response = new HttpResponse();
+        response.setStatus(HttpStatus.OK);
+        response.setBody(file);
+        return response;
     }
 }

--- a/src/main/java/webserver/handler/HomeHandler.java
+++ b/src/main/java/webserver/handler/HomeHandler.java
@@ -5,14 +5,14 @@ import webserver.httpMessage.HttpResponse;
 
 import java.io.File;
 
-import static webserver.handler.Path.INDEX_HTML;
-import static webserver.handler.Path.STATIC_PATH;
+import static webserver.handler.Path.HOME_PAGE;
+
 
 public class HomeHandler implements Handler {
 
     @Override
     public HttpResponse service(HttpRequest request) {
-        File file = new File(STATIC_PATH.path + INDEX_HTML.path);
+        File file = new File(HOME_PAGE.getRelativePath());
         return HttpResponse.from(file);
     }
 }

--- a/src/main/java/webserver/handler/HomeHandler.java
+++ b/src/main/java/webserver/handler/HomeHandler.java
@@ -1,0 +1,18 @@
+package webserver.handler;
+
+import webserver.httpMessage.HttpRequest;
+import webserver.httpMessage.HttpResponse;
+
+import java.io.File;
+
+import static webserver.handler.Path.INDEX_HTML;
+import static webserver.handler.Path.STATIC_PATH;
+
+public class HomeHandler implements Handler {
+
+    @Override
+    public HttpResponse service(HttpRequest request) {
+        File file = new File(STATIC_PATH.path + INDEX_HTML.path);
+        return HttpResponse.from(file);
+    }
+}

--- a/src/main/java/webserver/handler/LoginHandler.java
+++ b/src/main/java/webserver/handler/LoginHandler.java
@@ -4,6 +4,7 @@ import db.Database;
 import model.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import webserver.Session.SessionManger;
 import webserver.httpMessage.HttpRequest;
 import webserver.httpMessage.HttpResponse;
 import webserver.utils.HttpRequestParser;
@@ -43,6 +44,7 @@ public class LoginHandler implements Handler{
         response.redirect(HOME_PAGE.getPath());
         UUID uuid = UUID.randomUUID();
         response.setCookie(uuid);
+        SessionManger.addLoginUser(uuid.toString(), user);
         return response;
     }
 }

--- a/src/main/java/webserver/handler/LoginHandler.java
+++ b/src/main/java/webserver/handler/LoginHandler.java
@@ -1,12 +1,41 @@
 package webserver.handler;
 
+import db.Database;
+import model.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import webserver.httpMessage.HttpRequest;
 import webserver.httpMessage.HttpResponse;
+import webserver.utils.HttpRequestParser;
+
+import java.util.Map;
+
+import static webserver.handler.Path.HOME_PAGE;
+import static webserver.handler.Path.LOGIN_FAILED_PAGE;
+
 
 public class LoginHandler implements Handler{
 
+    private static final Logger logger = LoggerFactory.getLogger(LoginHandler.class);
+
     @Override
     public HttpResponse service(HttpRequest request) {
-        return null;
+        String body = request.getBody();
+        Map<String, String> loginQuery = HttpRequestParser.parseKeyValuePairs(body);
+        String id = loginQuery.get("userId");
+        String password = loginQuery.get("password");
+
+        User user = Database.findUserById(id);
+        if (user == null) {
+            logger.info("존재하지 않는 ID");
+            return HttpResponse.redirect(LOGIN_FAILED_PAGE.getPath());
+        }
+        if (!user.getPassword().equals(password)) {
+            logger.info("비밀번호 불일치 {}, {}", user.getPassword(), password);
+            return HttpResponse.redirect(LOGIN_FAILED_PAGE.getPath());
+        }
+
+        logger.info("{} : 로그인 성공", user.getUserId());
+        return HttpResponse.redirect(HOME_PAGE.getPath());
     }
 }

--- a/src/main/java/webserver/handler/LoginHandler.java
+++ b/src/main/java/webserver/handler/LoginHandler.java
@@ -9,6 +9,7 @@ import webserver.httpMessage.HttpResponse;
 import webserver.utils.HttpRequestParser;
 
 import java.util.Map;
+import java.util.UUID;
 
 import static webserver.handler.Path.HOME_PAGE;
 import static webserver.handler.Path.LOGIN_FAILED_PAGE;
@@ -26,16 +27,22 @@ public class LoginHandler implements Handler{
         String password = loginQuery.get("password");
 
         User user = Database.findUserById(id);
+        HttpResponse response = new HttpResponse();
         if (user == null) {
             logger.info("존재하지 않는 ID");
-            return HttpResponse.redirect(LOGIN_FAILED_PAGE.getPath());
+            response.redirect(LOGIN_FAILED_PAGE.getPath());
+            return response;
         }
         if (!user.getPassword().equals(password)) {
             logger.info("비밀번호 불일치 {}, {}", user.getPassword(), password);
-            return HttpResponse.redirect(LOGIN_FAILED_PAGE.getPath());
+            response.redirect(LOGIN_FAILED_PAGE.getPath());
+            return response;
         }
-
         logger.info("{} : 로그인 성공", user.getUserId());
-        return HttpResponse.redirect(HOME_PAGE.getPath());
+
+        response.redirect(HOME_PAGE.getPath());
+        UUID uuid = UUID.randomUUID();
+        response.setCookie(uuid);
+        return response;
     }
 }

--- a/src/main/java/webserver/handler/LoginHandler.java
+++ b/src/main/java/webserver/handler/LoginHandler.java
@@ -1,0 +1,12 @@
+package webserver.handler;
+
+import webserver.httpMessage.HttpRequest;
+import webserver.httpMessage.HttpResponse;
+
+public class LoginHandler implements Handler{
+
+    @Override
+    public HttpResponse service(HttpRequest request) {
+        return null;
+    }
+}

--- a/src/main/java/webserver/handler/LoginHandler.java
+++ b/src/main/java/webserver/handler/LoginHandler.java
@@ -34,7 +34,7 @@ public class LoginHandler implements Handler{
             response.redirect(LOGIN_FAILED_PAGE.getPath());
             return response;
         }
-        if (!user.getPassword().equals(password)) {
+        if (!user.verifyPassword(password)) {
             logger.info("비밀번호 불일치 {}, {}", user.getPassword(), password);
             response.redirect(LOGIN_FAILED_PAGE.getPath());
             return response;

--- a/src/main/java/webserver/handler/Path.java
+++ b/src/main/java/webserver/handler/Path.java
@@ -1,0 +1,14 @@
+package webserver.handler;
+
+public enum Path {
+    STATIC_PATH("src/main/resources/static"),
+    INDEX_HTML("/index.html"),
+    REGISTRATION("/registration"),
+    LOGIN("/login");
+
+    final String path;
+
+    Path(String s) {
+        this.path = s;
+    }
+}

--- a/src/main/java/webserver/handler/Path.java
+++ b/src/main/java/webserver/handler/Path.java
@@ -1,14 +1,24 @@
 package webserver.handler;
 
 public enum Path {
-    STATIC_PATH("src/main/resources/static"),
-    INDEX_HTML("/index.html"),
-    REGISTRATION("/registration"),
-    LOGIN("/login");
+    RESOURCE_PATH("src/main/resources/static"),
+    HOME_PAGE("/index.html"),
+    REGISTRATION_PAGE("/registration/index.html"),
+    LOGIN_PAGE("/login/index.html"),
+    LOGIN_FAILED_PAGE("/login/login_failed.html");
 
-    final String path;
+    private static final String staticPath = "src/main/resources/static";
+    private final String path;
 
     Path(String s) {
         this.path = s;
+    }
+    
+    public String getRelativePath() {
+        return staticPath + path; 
+    }
+
+    public String getPath() {
+        return path;
     }
 }

--- a/src/main/java/webserver/handler/RegistrationHandler.java
+++ b/src/main/java/webserver/handler/RegistrationHandler.java
@@ -1,0 +1,17 @@
+package webserver.handler;
+
+import webserver.httpMessage.HttpRequest;
+import webserver.httpMessage.HttpResponse;
+
+import java.io.File;
+
+import static webserver.handler.Path.*;
+
+public class RegistrationHandler implements Handler {
+
+    @Override
+    public HttpResponse service(HttpRequest request) {
+        File file = new File(STATIC_PATH.path + REGISTRATION.path + INDEX_HTML.path);
+        return HttpResponse.from(file);
+    }
+}

--- a/src/main/java/webserver/handler/RegistrationHandler.java
+++ b/src/main/java/webserver/handler/RegistrationHandler.java
@@ -2,6 +2,7 @@ package webserver.handler;
 
 import webserver.httpMessage.HttpRequest;
 import webserver.httpMessage.HttpResponse;
+import webserver.httpMessage.HttpStatus;
 
 import java.io.File;
 
@@ -12,6 +13,10 @@ public class RegistrationHandler implements Handler {
     @Override
     public HttpResponse service(HttpRequest request) {
         File file = new File(REGISTRATION_PAGE.getRelativePath());
-        return HttpResponse.from(file);
+
+        HttpResponse response = new HttpResponse();
+        response.setStatus(HttpStatus.OK);
+        response.setBody(file);
+        return response;
     }
 }

--- a/src/main/java/webserver/handler/RegistrationHandler.java
+++ b/src/main/java/webserver/handler/RegistrationHandler.java
@@ -11,7 +11,7 @@ public class RegistrationHandler implements Handler {
 
     @Override
     public HttpResponse service(HttpRequest request) {
-        File file = new File(STATIC_PATH.path + REGISTRATION.path + INDEX_HTML.path);
+        File file = new File(REGISTRATION_PAGE.getRelativePath());
         return HttpResponse.from(file);
     }
 }

--- a/src/main/java/webserver/handler/StaticFileHandler.java
+++ b/src/main/java/webserver/handler/StaticFileHandler.java
@@ -1,0 +1,30 @@
+package webserver.handler;
+
+import webserver.httpMessage.HttpRequest;
+import webserver.httpMessage.HttpResponse;
+
+import java.io.File;
+
+import static webserver.handler.Path.INDEX_HTML;
+import static webserver.handler.Path.STATIC_PATH;
+
+public class StaticFileHandler implements Handler {
+
+    @Override
+    public HttpResponse service(HttpRequest request) {
+        String uri = request.getUri();
+        File file = findFile(uri);
+        return HttpResponse.from(file);
+    }
+
+    private File findFile(String uri) {
+        if (isNotStaticFile(uri)) {
+            uri += INDEX_HTML.path;
+        }
+        return new File(STATIC_PATH.path + uri);
+    }
+
+    private static boolean isNotStaticFile(String uri) {
+        return !uri.contains(".");
+    }
+}

--- a/src/main/java/webserver/handler/StaticFileHandler.java
+++ b/src/main/java/webserver/handler/StaticFileHandler.java
@@ -2,6 +2,7 @@ package webserver.handler;
 
 import webserver.httpMessage.HttpRequest;
 import webserver.httpMessage.HttpResponse;
+import webserver.httpMessage.HttpStatus;
 
 import java.io.File;
 
@@ -13,7 +14,12 @@ public class StaticFileHandler implements Handler {
     public HttpResponse service(HttpRequest request) {
         String uri = request.getUri();
         File file = new File(RESOURCE_PATH.getPath() + uri);
-        return HttpResponse.from(file);
+
+        HttpResponse response = new HttpResponse();
+        response.setStatus(HttpStatus.OK);
+        response.setBody(file);
+
+        return response;
     }
 
 }

--- a/src/main/java/webserver/handler/StaticFileHandler.java
+++ b/src/main/java/webserver/handler/StaticFileHandler.java
@@ -5,26 +5,15 @@ import webserver.httpMessage.HttpResponse;
 
 import java.io.File;
 
-import static webserver.handler.Path.INDEX_HTML;
-import static webserver.handler.Path.STATIC_PATH;
+import static webserver.handler.Path.RESOURCE_PATH;
 
 public class StaticFileHandler implements Handler {
 
     @Override
     public HttpResponse service(HttpRequest request) {
         String uri = request.getUri();
-        File file = findFile(uri);
+        File file = new File(RESOURCE_PATH.getPath() + uri);
         return HttpResponse.from(file);
     }
 
-    private File findFile(String uri) {
-        if (isNotStaticFile(uri)) {
-            uri += INDEX_HTML.path;
-        }
-        return new File(STATIC_PATH.path + uri);
-    }
-
-    private static boolean isNotStaticFile(String uri) {
-        return !uri.contains(".");
-    }
 }

--- a/src/main/java/webserver/handler/UserCreateHandler.java
+++ b/src/main/java/webserver/handler/UserCreateHandler.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import webserver.httpMessage.HttpRequest;
 import webserver.httpMessage.HttpResponse;
+import webserver.httpMessage.HttpStatus;
 import webserver.utils.HttpRequestParser;
 
 import java.util.Map;
@@ -24,6 +25,11 @@ public class UserCreateHandler implements Handler {
         User user = User.from(userForm);
         Database.addUser(user);
         logger.debug("User created : {}", Database.findUserById(user.getUserId()));
-        return HttpResponse.redirect(HOME_PAGE.getPath());
+
+        HttpResponse response = new HttpResponse();
+        response.setStatus(HttpStatus.SEE_OTHER);
+        response.setLocation(HOME_PAGE.getPath());
+
+        return response;
     }
 }

--- a/src/main/java/webserver/handler/UserCreateHandler.java
+++ b/src/main/java/webserver/handler/UserCreateHandler.java
@@ -1,0 +1,29 @@
+package webserver.handler;
+
+import db.Database;
+import model.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import webserver.httpMessage.HttpRequest;
+import webserver.httpMessage.HttpResponse;
+import webserver.utils.HttpRequestParser;
+
+import java.util.Map;
+
+import static webserver.handler.Path.INDEX_HTML;
+
+public class UserCreateHandler implements Handler {
+
+    private static final Logger logger = LoggerFactory.getLogger(UserCreateHandler.class);
+
+    @Override
+    public HttpResponse service(HttpRequest request) {
+        String body = request.getBody();
+        Map<String, String> userForm = HttpRequestParser.parseKeyValuePairs(body);
+
+        User user = User.from(userForm);
+        Database.addUser(user);
+        logger.debug("User created : {}", Database.findUserById(user.getUserId()));
+        return HttpResponse.redirect(INDEX_HTML.path);
+    }
+}

--- a/src/main/java/webserver/handler/UserCreateHandler.java
+++ b/src/main/java/webserver/handler/UserCreateHandler.java
@@ -10,7 +10,7 @@ import webserver.utils.HttpRequestParser;
 
 import java.util.Map;
 
-import static webserver.handler.Path.INDEX_HTML;
+import static webserver.handler.Path.HOME_PAGE;
 
 public class UserCreateHandler implements Handler {
 
@@ -24,6 +24,6 @@ public class UserCreateHandler implements Handler {
         User user = User.from(userForm);
         Database.addUser(user);
         logger.debug("User created : {}", Database.findUserById(user.getUserId()));
-        return HttpResponse.redirect(INDEX_HTML.path);
+        return HttpResponse.redirect(HOME_PAGE.getPath());
     }
 }

--- a/src/main/java/webserver/httpMessage/HttpRequest.java
+++ b/src/main/java/webserver/httpMessage/HttpRequest.java
@@ -48,15 +48,7 @@ public class HttpRequest {
         return split[1];
     }
 
-    public String getHeaderByName(String headerName) {
-        return header.get(headerName);
-    }
-
     public String getBody() {
         return body;
-    }
-
-    public boolean hasCookie() {
-        return header.containsKey("Cookie");
     }
 }

--- a/src/main/java/webserver/httpMessage/HttpRequest.java
+++ b/src/main/java/webserver/httpMessage/HttpRequest.java
@@ -48,7 +48,15 @@ public class HttpRequest {
         return split[1];
     }
 
+    public String getHeaderByName(String headerName) {
+        return header.get(headerName);
+    }
+
     public String getBody() {
         return body;
+    }
+
+    public boolean hasCookie() {
+        return header.containsKey("Cookie");
     }
 }

--- a/src/main/java/webserver/httpMessage/HttpRequest.java
+++ b/src/main/java/webserver/httpMessage/HttpRequest.java
@@ -23,9 +23,7 @@ public class HttpRequest {
         this.requestTarget = getRequestTarget();
         this.header = header;
         this.body = body;
-    }
 
-    public void log() {
         logger.info(startLine);
     }
 

--- a/src/main/java/webserver/httpMessage/HttpRequest.java
+++ b/src/main/java/webserver/httpMessage/HttpRequest.java
@@ -2,13 +2,7 @@ package webserver.httpMessage;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import webserver.utils.HttpRequestParser;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.HashMap;
 import java.util.Map;
 
 public class HttpRequest {
@@ -17,56 +11,18 @@ public class HttpRequest {
     public static final String NO_QUERY_PARAMS = "";
     public static final String BLANK = " ";
     public static final String REQUEST_TARGET_DELIMITER = "?";
-    public static final String CONTENT_LENGTH = "Content-Length";
-    public static final String HEADER_DELIMITER = ":?\\s";
+
 
     private final String startLine;
     private final String requestTarget;
     private final Map<String, String> header;
-    private final Map<String, String> body;
+    private final String body;
 
-    public HttpRequest(String startLine, Map<String, String> header, Map<String, String> body) {
+    public HttpRequest(String startLine, Map<String, String> header, String body) {
         this.startLine = startLine;
         this.requestTarget = getRequestTarget();
         this.header = header;
         this.body = body;
-    }
-
-    public static HttpRequest from(InputStream in) throws IOException {
-        BufferedReader br = new BufferedReader(new InputStreamReader(in));
-
-        String startLine = br.readLine();
-        Map<String, String> header = readHeader(br);
-        Map<String, String> body = readBody(br, header.get(CONTENT_LENGTH));
-        return new HttpRequest(startLine, header, body);
-    }
-
-    private static Map<String, String> readBody(BufferedReader br, String contentLength) throws IOException {
-        if (contentLength == null) {
-            return Map.of();
-        }
-
-        String body = readBodyContent(br, contentLength);
-        return HttpRequestParser.parseKeyValuePairs(body);
-    }
-
-    private static String readBodyContent(BufferedReader br, String contentLength) throws IOException {
-        StringBuilder bodyBuffer = new StringBuilder();
-        int length = Integer.parseInt(contentLength);
-        for (int i = 0; i < length; i++) {
-            bodyBuffer.append((char) br.read());
-        }
-        return bodyBuffer.toString();
-    }
-
-    private static Map<String, String> readHeader(BufferedReader br) throws IOException {
-        Map<String, String> header = new HashMap<>();
-        String line;
-        while (!(line = br.readLine()).isEmpty()) {
-            String[] split = line.split(HEADER_DELIMITER);
-            header.put(split[0], split[1]);
-        }
-        return header;
     }
 
     public void log() {
@@ -94,7 +50,7 @@ public class HttpRequest {
         return split[1];
     }
 
-    public Map<String, String> getBody() {
+    public String getBody() {
         return body;
     }
 }

--- a/src/main/java/webserver/httpMessage/HttpRequestReader.java
+++ b/src/main/java/webserver/httpMessage/HttpRequestReader.java
@@ -1,0 +1,59 @@
+package webserver.httpMessage;
+
+import webserver.utils.HttpRequestParser;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URLDecoder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class HttpRequestReader {
+
+    public static final String UTF_8 = "UTF-8";
+    public static final String CONTENT_LENGTH = "Content-Length";
+    public static final String EMPTY_BODY = "";
+
+    private final BufferedReader br;
+
+    public HttpRequestReader(InputStream in) {
+        br = new BufferedReader(new InputStreamReader(in));
+    }
+
+    public HttpRequest readHttpRequest() throws IOException {
+        String startLine = br.readLine();
+        Map<String, String> header = readHeader();
+        String body = readBody(header.get(CONTENT_LENGTH));
+        return new HttpRequest(startLine, header, body);
+    }
+
+    private String readBody(String contentLength) throws IOException {
+        if (contentLength == null) {
+            return EMPTY_BODY;
+        }
+
+        return readBodyContent(contentLength);
+    }
+
+    private String readBodyContent(String contentLength) throws IOException {
+        StringBuilder bodyBuffer = new StringBuilder();
+        int length = Integer.parseInt(contentLength);
+        for (int i = 0; i < length; i++) {
+            bodyBuffer.append((char) br.read());
+        }
+        return URLDecoder.decode(bodyBuffer.toString(), UTF_8);
+    }
+
+    private Map<String, String> readHeader() throws IOException {
+        List<String> requestHeader = new ArrayList<>();
+        String line;
+        while (!(line = br.readLine()).isEmpty()) {
+            requestHeader.add(line);
+        }
+        return HttpRequestParser.parseHeader(requestHeader);
+    }
+
+}

--- a/src/main/java/webserver/httpMessage/HttpResponse.java
+++ b/src/main/java/webserver/httpMessage/HttpResponse.java
@@ -100,10 +100,6 @@ public class HttpResponse {
     }
 
     public void setCookie(UUID uuid) {
-        header += "Cookie: sid=" + uuid + "; Path=/ \r\n";
-    }
-
-    public void remainCookie(String cookie) {
-        header += "Cookie: " + cookie;
+        header += "Set-Cookie: sid=" + uuid + "; Path=/ \r\n";
     }
 }

--- a/src/main/java/webserver/httpMessage/HttpResponse.java
+++ b/src/main/java/webserver/httpMessage/HttpResponse.java
@@ -26,7 +26,7 @@ public class HttpResponse {
     }
 
     public static HttpResponse from(File file) {
-        List<String> header = getHeader(TypeMapper.getContentType(file), (int) file.length());
+        List<String> header = getOkHeader(TypeMapper.getContentType(file), (int) file.length());
         byte[] body = readFile(file);
         return new HttpResponse(header, body);
     }
@@ -45,7 +45,7 @@ public class HttpResponse {
         return body;
     }
 
-    public List<String> getHeader() {
+    public List<String> getOkHeader() {
         return header;
     }
 
@@ -53,7 +53,7 @@ public class HttpResponse {
         return body;
     }
 
-    private static List<String> getHeader(String contentType, int bodyLength) {
+    private static List<String> getOkHeader(String contentType, int bodyLength) {
         List<String> header = new ArrayList<>();
 
         header.add(HttpStatus.OK.getStatusMessage());
@@ -77,7 +77,7 @@ public class HttpResponse {
     public void send(OutputStream out) {
         DataOutputStream dos = new DataOutputStream(out);
         try {
-            writeHeader(getHeader(), dos);
+            writeHeader(getOkHeader(), dos);
             writeBody(getBody(), dos);
             dos.flush();
         } catch (IOException e) {

--- a/src/main/java/webserver/utils/HttpRequestParser.java
+++ b/src/main/java/webserver/utils/HttpRequestParser.java
@@ -1,25 +1,34 @@
 package webserver.utils;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class HttpRequestParser {
 
-    public static final String UTF_8 = "UTF-8";
     public static final String QUERY_DELIMITER = "&";
     public static final String KEY_VALUE_DELIMITER = "=";
+    public static final String HEADER_DELIMITER = ":?\\s";
 
-    public static Map<String, String> parseKeyValuePairs(String query) throws UnsupportedEncodingException {
+    public static Map<String, String> parseKeyValuePairs(String query) {
         Map<String, String> queryPairs = new HashMap<>();
         String[] pairs = query.split(QUERY_DELIMITER);
 
         for (String pair : pairs) {
             String[] split = pair.split(KEY_VALUE_DELIMITER);
-            queryPairs.put(URLDecoder.decode(split[0], UTF_8), URLDecoder.decode(split[1], UTF_8));
+            queryPairs.put(split[0], split[1]);
         }
 
         return queryPairs;
+    }
+
+    public static Map<String, String> parseHeader(List<String> header) {
+        Map<String, String> parsedHeader = new HashMap<>();
+
+        for (String line : header) {
+            String[] split = line.split(HEADER_DELIMITER);
+            parsedHeader.put(split[0], split[1]);
+        }
+        return parsedHeader;
     }
 }

--- a/src/main/java/webserver/utils/HttpRequestParser.java
+++ b/src/main/java/webserver/utils/HttpRequestParser.java
@@ -8,7 +8,7 @@ public class HttpRequestParser {
 
     public static final String QUERY_DELIMITER = "&";
     public static final String KEY_VALUE_DELIMITER = "=";
-    public static final String HEADER_DELIMITER = ":?\\s";
+    public static final String HEADER_DELIMITER = ":\\s?";
 
     public static Map<String, String> parseKeyValuePairs(String query) {
         Map<String, String> queryPairs = new HashMap<>();

--- a/src/main/resources/static/global.css
+++ b/src/main/resources/static/global.css
@@ -39,6 +39,15 @@
   text-align: center;
 }
 
+.login-fail {
+  font-weight: 400;
+  font-size: 20px;
+  line-height: 38.19px;
+  padding: 20px 0;
+  text-align: center;
+  color: #dd1111;
+}
+
 .btn {
   border: none;
   border-radius: 8px;

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -13,7 +13,7 @@
         <a href="/"><img src="./img/signiture.svg" /></a>
         <ul class="header__menu">
           <li class="header__menu__item">
-            <a class="btn btn_contained btn_size_s" href="/login">로그인</a>
+            <a class="btn btn_contained btn_size_s" href="/login/index.html">로그인</a>
           </li>
           <li class="header__menu__item">
             <a class="btn btn_ghost btn_size_s" href="/registration">

--- a/src/main/resources/static/login/index.html
+++ b/src/main/resources/static/login/index.html
@@ -23,11 +23,12 @@
       </header>
       <div class="page">
         <h2 class="page-title">로그인</h2>
-        <form class="form">
+        <form class="form" method="post" action="/login">
           <div class="textfield textfield_size_s">
             <p class="title_textfield">아이디</p>
             <input
               class="input_textfield"
+              name="userId"
               placeholder="아이디를 입력해주세요"
               autocomplete="username"
             />
@@ -36,6 +37,7 @@
             <p class="title_textfield">비밀번호</p>
             <input
               class="input_textfield"
+              name="password"
               type="password"
               placeholder="비밀번호를 입력해주세요"
               autocomplete="current-password"
@@ -45,7 +47,6 @@
             id="login-btn"
             class="btn btn_contained btn_size_m"
             style="margin-top: 24px"
-            type="button"
           >
             로그인
           </button>

--- a/src/main/resources/static/login/login_failed.html
+++ b/src/main/resources/static/login/login_failed.html
@@ -12,7 +12,7 @@
         <a href="/"><img src="../img/signiture.svg" /></a>
         <ul class="header__menu">
           <li class="header__menu__item">
-            <a class="btn btn_contained btn_size_s" href="/login/index.html">로그인</a>
+            <a class="btn btn_contained btn_size_s" href="/login">로그인</a>
           </li>
           <li class="header__menu__item">
             <a class="btn btn_ghost btn_size_s" href="/registration">
@@ -22,51 +22,34 @@
         </ul>
       </header>
       <div class="page">
-        <h2 class="page-title">회원가입</h2>
-        <form class="form" action="/create" method="post">
+        <h2 class="page-title">로그인</h2>
+        <h3 class="login-fail">로그인에 실패했습니다.</h3>
+        <form class="form" method="post" action="/login">
           <div class="textfield textfield_size_s">
             <p class="title_textfield">아이디</p>
             <input
               class="input_textfield"
+              name="userId"
               placeholder="아이디를 입력해주세요"
               autocomplete="username"
-              name="userId"
             />
           </div>
           <div class="textfield textfield_size_s">
             <p class="title_textfield">비밀번호</p>
             <input
               class="input_textfield"
+              name="password"
               type="password"
               placeholder="비밀번호를 입력해주세요"
               autocomplete="current-password"
-              name="password"
-            />
-          </div>
-          <div class="textfield textfield_size_s">
-            <p class="title_textfield">닉네임</p>
-            <input
-                    class="input_textfield"
-                    placeholder="닉네임을 입력해주세요"
-                    autocomplete="username"
-                    name="name"
-            />
-          </div>
-          <div class="textfield textfield_size_s">
-            <p class="title_textfield">이메일</p>
-            <input
-                    class="input_textfield"
-                    placeholder="이메일을 입력해주세요"
-                    autocomplete="email"
-                    name="email"
             />
           </div>
           <button
-            id="registration-btn"
+            id="login-btn"
             class="btn btn_contained btn_size_m"
             style="margin-top: 24px"
           >
-            회원가입
+            로그인
           </button>
         </form>
       </div>

--- a/src/test/java/webserver/httpMessage/HttpRequestTest.java
+++ b/src/test/java/webserver/httpMessage/HttpRequestTest.java
@@ -13,7 +13,7 @@ class HttpRequestTest {
 
     @BeforeEach
     void init() {
-        httpRequest = new HttpRequest("GET /create?userId=cori&password=1234&name=cori&email=cori@naver.com HTTP/1.1 \r\n", new HashMap<>(), new HashMap<>());
+        httpRequest = new HttpRequest("GET /create?userId=cori&password=1234&name=cori&email=cori@naver.com HTTP/1.1 \r\n", new HashMap<>(), "");
     }
 
     @Test

--- a/src/test/java/webserver/httpMessage/HttpResponseTest.java
+++ b/src/test/java/webserver/httpMessage/HttpResponseTest.java
@@ -17,7 +17,8 @@ class HttpResponseTest {
     @DisplayName("HttpResponse는 file 내용을 body로 가지고 있어야 한다.")
     void from() throws IOException {
         File file = new File(INDEX_HTML_PATH);
-        HttpResponse actual = HttpResponse.from(file);
+        HttpResponse actual = new HttpResponse();
+        actual.setBody(file);
 
         byte[] expected = Files.readAllBytes(Path.of(INDEX_HTML_PATH));
         Assertions.assertThat(actual.getBody()).isEqualTo(expected);

--- a/src/test/java/webserver/utils/HttpRequestParserTest.java
+++ b/src/test/java/webserver/utils/HttpRequestParserTest.java
@@ -11,7 +11,7 @@ class HttpRequestParserTest {
     @Test
     @DisplayName("쿼리 파라미터를 Map으로 변환")
     void parseQueryParams() throws UnsupportedEncodingException {
-        String query = "userId=cori123&password=1234&name=cori&email=cori%40naver.com";
+        String query = "userId=cori123&password=1234&name=cori&email=cori@naver.com";
         Map<String, String> userForm = HttpRequestParser.parseKeyValuePairs(query);
 
         Map<String, String> expected = Map.of(


### PR DESCRIPTION
## 구현 내용
- URI 별 동작을 정의해둔 `Handler` 구현체를 각각 정의
  - URI에 따라 `HttpResponse`를 반환하는 메서드를 클래스 단위로 리팩터링
<br></br>
- 로그인 기능 구현
  - 로그인 성공 시
    - 쿠키에 세션 아이디 추가
    - `SessionManager`에 `SessionId, User`를 key-value로 추가
    - `index.html`로 리다이렉트
  - 로그인 실패 시
    - `/login/login_failed.html`로 리다이렉트

<br></br>

## 고민 사항
### 정적 파일 경로에 대한 고민
자주 사용되는 정적 파일의 경로를 `Path` 열거형에 저장했습니다.  
만약 정적 파일들이 더 많아진다면 추가된 파일들의 경로를 모두 추가해야 된다는 문제가 있는데, 정적 파일들을 어떻게 해야 효율적으로 관리할 수 있을지에 대한 고민이 있었습니다.

### `HttpResponse` 객체에 대한 고민
이전에는 헤더와 바디가 모두 간단했기에, `getOkHeader` `getRedirectHeader`과 같은 메서드를 정의해 사용했습니다.  
이번 미션을 진행하면서 쿠키가 추가될 수도 있고, 추가되지 않을 수도 있었는데, 쿠키 추가를 위해 `getRedirectHeaderWithCookie`와 같은 메서드를 추가하는 건 말이 안된다는 생각이 들었습니다.  
그래서 결국 `HttpRequest`객체를 생성자로 생성하고, 헤더에 추가할 정보를 `setStatus(Status)`, `setCookie(UUID)`, `setLocation(String)`과 같은 세터를 추가하도록 변경했습니다.  
현재 방법이 헤더에 필요한 속성을 추가할 수 있다는 점은 좋지만, 추가 기능을 구현할 때 실수로 헤더에 필요한 정보를 누락하거나 하는 경우가 생긴다는 단점이 있는 것 같습니다.

<br></br>

## 기타
### 로그인  HTTP 메시지의 쿠키
- 로그인 요청 메시지에 대한 Response Cookies에 `sid=a3dad396-a055-4666-9ff0-3a84e2db1e42` 존재한다.
<img width="812" alt="스크린샷 2024-03-21 오전 1 24 12" src="https://github.com/codesquad-members-2024/be-was-neon/assets/110909423/28c4f384-8bf6-4a9a-aa9d-d2a8aabe9744">

### 로그인 요청에 대한 HTTP 리다이렉트 메시지의 쿠키
- 로그인 이후 `index.html`로 리다이렉션 요청의 Request Cookies에 `sid=a3dad396-a055-4666-9ff0-3a84e2db1e42`가 포함된다.
<img width="809" alt="스크린샷 2024-03-21 오전 1 24 20" src="https://github.com/codesquad-members-2024/be-was-neon/assets/110909423/d3e38089-fa98-42c5-a5bb-9584d6a185f3">
