### PR TITLE
[yelly] step 7 H2 데이터베이스 연동 및 javaDoc 작성

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,3 +202,10 @@ sequenceDiagram
 - [x] 추가할 때 마다 id가 1씩 증가한다
 - [x] 게시물 아이디로 찾을 수 있다
 - [x] 작성자 아이디로 찾을 수 있다
+
+## H2 Database
+- 테이블 생성할 때 `USER`는 예약어 -> 테이블 이름 `USERS`로 수정
+- [x] User 객체를 저장할 수 있다
+- [x] 특정 User를 userId로 찾을 수 있다
+- [x] 모든 User를 찾을 수 있다
+- [x] 특정 User를 userId로 제거할 수 있다 

--- a/README.md
+++ b/README.md
@@ -184,8 +184,10 @@ sequenceDiagram
 - [x] 요청 URI에 해당하는 정적 파일을 매핑할 수 있다
 - [x] 존재하지 않는 URI는 빈 Optional을 반환할 수 있다
 
-## LoginManager
+## UserManager
 - [x] 데이터베이스에 등록된 유저인지 검증할 수 있다
+- [x] 회원가입에 대한 결과를 참/거짓으로 반환할 수 있다
+- [x] 회원가입된 모든 유저들을 반환할 수 있다
 
 ## SessionManager
 - [x] 세션 ID를 UUID 로 생성할 수 있다

--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,10 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.4.2'
 
-    implementation 'ch.qos.logback:logback-classic:1.2.3'
+    implementation 'ch.qos.logback:logback-classic:1.4.14'
     testImplementation 'org.assertj:assertj-core:3.16.1'
 
+    implementation 'com.h2database:h2:2.2.224' // H2 데이터베이스 추가
 
 }
 

--- a/src/main/java/db/ArticleDatabase.java
+++ b/src/main/java/db/ArticleDatabase.java
@@ -1,13 +1,12 @@
 package db;
 
-import java.sql.SQLException;
 import java.util.Optional;
 import model.Article;
 
 public interface ArticleDatabase {
-    Article add(Article article) throws SQLException;
+    Article add(Article article);
 
-    Optional<Article> findById(long articleId) throws SQLException;
+    Optional<Article> findById(long articleId);
 
-    Optional<Article> findLatest(String userId) throws SQLException;
+    Optional<Article> findLatest(String userId);
 }

--- a/src/main/java/db/ArticleDatabase.java
+++ b/src/main/java/db/ArticleDatabase.java
@@ -1,0 +1,13 @@
+package db;
+
+import java.sql.SQLException;
+import java.util.Optional;
+import model.Article;
+
+public interface ArticleDatabase {
+    Article add(Article article) throws SQLException;
+
+    Optional<Article> findById(long articleId) throws SQLException;
+
+    Optional<Article> findLatest(String userId) throws SQLException;
+}

--- a/src/main/java/db/ArticleDatabaseH2.java
+++ b/src/main/java/db/ArticleDatabaseH2.java
@@ -19,7 +19,7 @@ public class ArticleDatabaseH2 implements ArticleDatabase {
     private final DataSource dataSource = DataSourceUtil.getDataSource();
 
     @Override
-    public Article add(Article article) throws SQLException {
+    public Article add(Article article) {
         String sql = "INSERT INTO ARTICLE(BODY, CREATED_BY, CREATED_AT, IMAGE_PATH) VALUES (?, ?, ?, ?)";
 
         Connection con = null;
@@ -42,7 +42,6 @@ public class ArticleDatabaseH2 implements ArticleDatabase {
             }
         } catch (SQLException e) {
             logger.error("DB INSERT FAILED={}", e.getMessage());
-            throw e;
         } finally {
             close(con, pstmt, rs);
         }
@@ -50,7 +49,7 @@ public class ArticleDatabaseH2 implements ArticleDatabase {
     }
 
     @Override
-    public Optional<Article> findById(long articleId) throws SQLException {
+    public Optional<Article> findById(long articleId) {
         String sql = "SELECT * FROM ARTICLE WHERE ARTICLE_ID = ?";
 
         Connection con = null;
@@ -75,7 +74,7 @@ public class ArticleDatabaseH2 implements ArticleDatabase {
     }
 
     @Override
-    public Optional<Article> findLatest(String userId) throws SQLException {
+    public Optional<Article> findLatest(String userId) {
         String sql = "SELECT * FROM ARTICLE WHERE CREATED_BY = ? ORDER BY CREATED_AT DESC LIMIT 1";
 
         Connection con = null;

--- a/src/main/java/db/ArticleDatabaseH2.java
+++ b/src/main/java/db/ArticleDatabaseH2.java
@@ -14,10 +14,22 @@ import org.h2.util.JdbcUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * H2 데이터베이스를 사용하는 Article 데이터베이스 클래스입니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public class ArticleDatabaseH2 implements ArticleDatabase {
     private static final Logger logger = LoggerFactory.getLogger(ArticleDatabaseH2.class);
     private final DataSource dataSource = DataSourceUtil.getDataSource();
 
+    /**
+     * Article을 데이터베이스에 추가합니다.
+     *
+     * @param article 추가할 Article 객체
+     * @return 추가된 Article 객체
+     */
     @Override
     public Article add(Article article) {
         String sql = "INSERT INTO ARTICLE(BODY, CREATED_BY, CREATED_AT, IMAGE_PATH) VALUES (?, ?, ?, ?)";
@@ -48,6 +60,12 @@ public class ArticleDatabaseH2 implements ArticleDatabase {
         return article;
     }
 
+    /**
+     * 주어진 articleId에 해당하는 Article을 데이터베이스에서 찾아 반환합니다.
+     *
+     * @param articleId 찾을 Article의 ID
+     * @return Optional<Article> 객체
+     */
     @Override
     public Optional<Article> findById(long articleId) {
         String sql = "SELECT * FROM ARTICLE WHERE ARTICLE_ID = ?";
@@ -73,6 +91,12 @@ public class ArticleDatabaseH2 implements ArticleDatabase {
         return Optional.empty();
     }
 
+    /**
+     * 주어진 userId로 작성된 가장 최근의 Article을 데이터베이스에서 찾아 반환합니다.
+     *
+     * @param userId 작성자의 ID
+     * @return Optional<Article> 객체
+     */
     @Override
     public Optional<Article> findLatest(String userId) {
         String sql = "SELECT * FROM ARTICLE WHERE CREATED_BY = ? ORDER BY CREATED_AT DESC LIMIT 1";
@@ -98,6 +122,11 @@ public class ArticleDatabaseH2 implements ArticleDatabase {
         return Optional.empty();
     }
 
+    /**
+     * 주어진 articleId에 해당하는 Article을 데이터베이스에서 삭제합니다.
+     *
+     * @param articleId 삭제할 Article의 ID
+     */
     public void delete(long articleId) {
         String sql = "DELETE FROM ARTICLE WHERE ARTICLE_ID = ?";
         Connection con = null;
@@ -109,12 +138,15 @@ public class ArticleDatabaseH2 implements ArticleDatabase {
             pstmt.setLong(1, articleId);
             pstmt.executeUpdate();
         } catch (SQLException e) {
-            logger.error("DB SELECT FAILED={}", e.getMessage());
+            logger.error("DB DELETE FAILED={}", e.getMessage());
         } finally {
             close(con, pstmt, null);
         }
     }
 
+    /**
+     * ARTICLE 테이블의 ARTICLE_ID 컬럼을 1부터 재설정합니다.
+     */
     public void resetIdWithOne() {
         String sql = "ALTER TABLE ARTICLE ALTER COLUMN ARTICLE_ID RESTART WITH 1";
 
@@ -126,7 +158,7 @@ public class ArticleDatabaseH2 implements ArticleDatabase {
             pstmt = con.prepareStatement(sql);
             pstmt.executeUpdate();
         } catch (SQLException e) {
-            logger.error("DB SELECT FAILED={}", e.getMessage());
+            logger.error("DB ALTER FAILED={}", e.getMessage());
         } finally {
             close(con, pstmt, null);
         }

--- a/src/main/java/db/ArticleDatabaseH2.java
+++ b/src/main/java/db/ArticleDatabaseH2.java
@@ -1,0 +1,157 @@
+package db;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import javax.sql.DataSource;
+import model.Article;
+import org.h2.util.JdbcUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ArticleDatabaseH2 implements ArticleDatabase {
+    private static final Logger logger = LoggerFactory.getLogger(ArticleDatabaseH2.class);
+    private final DataSource dataSource = DataSourceUtil.getDataSource();
+
+    @Override
+    public Article add(Article article) throws SQLException {
+        String sql = "INSERT INTO ARTICLE(BODY, CREATED_BY, CREATED_AT, IMAGE_PATH) VALUES (?, ?, ?, ?)";
+
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+
+        try {
+            con = getConnection();
+            pstmt = con.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
+            pstmt.setString(1, article.body());
+            pstmt.setString(2, article.createdBy());
+            pstmt.setTimestamp(3, Timestamp.valueOf(article.createdAt()));
+            pstmt.setString(4, article.imagePath());
+            pstmt.executeUpdate();
+
+            rs = pstmt.getGeneratedKeys();
+            if (rs.next()) {
+                long generatedId = rs.getLong(1);
+                article.setId(generatedId);
+            }
+        } catch (SQLException e) {
+            logger.error("DB INSERT FAILED={}", e.getMessage());
+            throw e;
+        } finally {
+            close(con, pstmt, rs);
+        }
+        return article;
+    }
+
+    @Override
+    public Optional<Article> findById(long articleId) throws SQLException {
+        String sql = "SELECT * FROM ARTICLE WHERE ARTICLE_ID = ?";
+
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+
+        try {
+            con = getConnection();
+            pstmt = con.prepareStatement(sql);
+            pstmt.setLong(1, articleId);
+            rs = pstmt.executeQuery();
+            if (rs.next()) {
+                Article article = convertToArticle(rs);
+                return Optional.of(article);
+            }
+        } catch (SQLException e) {
+            logger.error("DB SELECT FAILED={}", e.getMessage());
+        } finally {
+            close(con, pstmt, rs);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Article> findLatest(String userId) throws SQLException {
+        String sql = "SELECT * FROM ARTICLE WHERE CREATED_BY = ? ORDER BY CREATED_AT DESC LIMIT 1";
+
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+
+        try {
+            con = getConnection();
+            pstmt = con.prepareStatement(sql);
+            pstmt.setString(1, userId);
+            rs = pstmt.executeQuery();
+            if (rs.next()) {
+                Article article = convertToArticle(rs);
+                return Optional.of(article);
+            }
+        } catch (SQLException e) {
+            logger.error("DB SELECT FAILED={}", e.getMessage());
+        } finally {
+            close(con, pstmt, rs);
+        }
+        return Optional.empty();
+    }
+
+    public void delete(long articleId) {
+        String sql = "DELETE FROM ARTICLE WHERE ARTICLE_ID = ?";
+        Connection con = null;
+        PreparedStatement pstmt = null;
+
+        try {
+            con = getConnection();
+            pstmt = con.prepareStatement(sql);
+            pstmt.setLong(1, articleId);
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            logger.error("DB SELECT FAILED={}", e.getMessage());
+        } finally {
+            close(con, pstmt, null);
+        }
+    }
+
+    public void resetIdWithOne() {
+        String sql = "ALTER TABLE ARTICLE ALTER COLUMN ARTICLE_ID RESTART WITH 1";
+
+        Connection con = null;
+        PreparedStatement pstmt = null;
+
+        try {
+            con = getConnection();
+            pstmt = con.prepareStatement(sql);
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            logger.error("DB SELECT FAILED={}", e.getMessage());
+        } finally {
+            close(con, pstmt, null);
+        }
+    }
+
+    private Article convertToArticle(ResultSet rs) throws SQLException {
+        long articleId = rs.getLong("article_id");
+        String body = rs.getString("body");
+        String createdBy = rs.getString("created_by");
+        LocalDateTime createdAt = rs.getTimestamp("created_at").toLocalDateTime();
+        String imagePath = rs.getString("image_path");
+
+        return new Article(body, createdBy, createdAt, imagePath).setId(articleId);
+    }
+
+    private void close(Connection con, Statement stmt, ResultSet rs) {
+        JdbcUtils.closeSilently(con);
+        JdbcUtils.closeSilently(stmt);
+        JdbcUtils.closeSilently(rs);
+    }
+
+    private Connection getConnection() throws SQLException {
+        Connection con = dataSource.getConnection();
+        logger.debug("connection={}, class={}", con, con.getClass());
+        return con;
+    }
+}

--- a/src/main/java/db/ArticleDatabaseInMemory.java
+++ b/src/main/java/db/ArticleDatabaseInMemory.java
@@ -9,8 +9,8 @@ import model.Article;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ArticleDatabase {
-    private static final Logger logger = LoggerFactory.getLogger(ArticleDatabase.class);
+public class ArticleDatabaseInMemory {
+    private static final Logger logger = LoggerFactory.getLogger(ArticleDatabaseInMemory.class);
     private static final AtomicLong sequence = new AtomicLong(0L);
     private static final Long INCREASE_STEP = 1L;
     private static final Map<Long, Article> articles = new ConcurrentHashMap<>();

--- a/src/main/java/db/ArticleDatabaseInMemory.java
+++ b/src/main/java/db/ArticleDatabaseInMemory.java
@@ -9,25 +9,53 @@ import model.Article;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * 메모리 내부 데이터베이스를 사용하는 Article 데이터베이스 클래스입니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public class ArticleDatabaseInMemory {
     private static final Logger logger = LoggerFactory.getLogger(ArticleDatabaseInMemory.class);
     private static final AtomicLong sequence = new AtomicLong(0L);
     private static final Long INCREASE_STEP = 1L;
     private static final Map<Long, Article> articles = new ConcurrentHashMap<>();
 
+    /**
+     * 주어진 Article을 데이터베이스에 추가합니다.
+     *
+     * @param article 추가할 Article 객체
+     */
     public static void add(Article article) {
         articles.put(getNextArticleId(), article);
         logger.debug("[Database] Success Add Article={}", article.body());
     }
 
+    /**
+     * 다음 Article의 ID를 생성하고 반환합니다.
+     *
+     * @return 다음 Article의 ID
+     */
     public static long getNextArticleId() {
         return sequence.addAndGet(INCREASE_STEP);
     }
 
+    /**
+     * 주어진 ID에 해당하는 Article을 데이터베이스에서 찾아 반환합니다.
+     *
+     * @param id 찾을 Article의 ID
+     * @return ID에 해당하는 Article 객체
+     */
     public static Article findById(long id) {
         return articles.get(id);
     }
 
+    /**
+     * 주어진 사용자가 작성한 최신 Article을 데이터베이스에서 찾아 반환합니다.
+     *
+     * @param userId 작성자의 ID
+     * @return Optional<Article> 객체
+     */
     public static Optional<Article> findLatest(String userId) {
         return articles.values().stream()
                 .filter(article -> article.isCreatedBy(userId))
@@ -36,6 +64,9 @@ public class ArticleDatabaseInMemory {
                 .findAny();
     }
 
+    /**
+     * 데이터베이스의 모든 Article을 지웁니다.
+     */
     public static void clear() {
         articles.clear();
         sequence.set(0L);

--- a/src/main/java/db/ArticleDatabaseInMemory.java
+++ b/src/main/java/db/ArticleDatabaseInMemory.java
@@ -20,7 +20,7 @@ public class ArticleDatabaseInMemory {
         logger.debug("[Database] Success Add Article={}", article.body());
     }
 
-    private static long getNextArticleId() {
+    public static long getNextArticleId() {
         return sequence.addAndGet(INCREASE_STEP);
     }
 

--- a/src/main/java/db/ConnectionConst.java
+++ b/src/main/java/db/ConnectionConst.java
@@ -1,0 +1,7 @@
+package db;
+
+public abstract class ConnectionConst {
+    public static final String URL = "jdbc:h2:tcp://localhost/~/was";
+    public static final String USERNAME = "sa";
+    public static final String PASSWORD = "";
+}

--- a/src/main/java/db/DataSourceUtil.java
+++ b/src/main/java/db/DataSourceUtil.java
@@ -1,0 +1,33 @@
+package db;
+
+import static db.ConnectionConst.PASSWORD;
+import static db.ConnectionConst.URL;
+import static db.ConnectionConst.USERNAME;
+
+import javax.sql.DataSource;
+import org.h2.jdbcx.JdbcDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DataSourceUtil {
+    private static final Logger logger = LoggerFactory.getLogger(DataSourceUtil.class);
+    private static volatile JdbcDataSource dataSource;
+
+    private DataSourceUtil() {
+    }
+
+    public static synchronized DataSource getDataSource() {
+        if (dataSource == null) {
+            synchronized (DataSourceUtil.class) {
+                if (dataSource == null) {
+                    dataSource = new JdbcDataSource();
+                    dataSource.setURL(URL);
+                    dataSource.setUser(USERNAME);
+                    dataSource.setPassword(PASSWORD);
+                }
+            }
+        }
+        logger.debug("get datasource = {}", dataSource);
+        return dataSource;
+    }
+}

--- a/src/main/java/db/DataSourceUtil.java
+++ b/src/main/java/db/DataSourceUtil.java
@@ -9,6 +9,12 @@ import org.h2.jdbcx.JdbcDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * 데이터베이스 연결을 설정하는 유틸리티 클래스입니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public class DataSourceUtil {
     private static final Logger logger = LoggerFactory.getLogger(DataSourceUtil.class);
     private static volatile JdbcDataSource dataSource;
@@ -16,6 +22,11 @@ public class DataSourceUtil {
     private DataSourceUtil() {
     }
 
+    /**
+     * 데이터베이스의 DataSource를 반환합니다.
+     *
+     * @return DataSource 객체
+     */
     public static synchronized DataSource getDataSource() {
         if (dataSource == null) {
             synchronized (DataSourceUtil.class) {

--- a/src/main/java/db/UserDatabase.java
+++ b/src/main/java/db/UserDatabase.java
@@ -10,4 +10,6 @@ public interface UserDatabase {
     Collection<User> findAll();
 
     Optional<User> findById(String userId);
+
+    void delete(String userId);
 }

--- a/src/main/java/db/UserDatabase.java
+++ b/src/main/java/db/UserDatabase.java
@@ -1,0 +1,14 @@
+package db;
+
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.Optional;
+import model.User;
+
+public interface UserDatabase {
+    void addUser(User user) throws SQLException;
+
+    Collection<User> findAll() throws SQLException;
+
+    Optional<User> findUserById(String userId);
+}

--- a/src/main/java/db/UserDatabase.java
+++ b/src/main/java/db/UserDatabase.java
@@ -1,14 +1,13 @@
 package db;
 
-import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Optional;
 import model.User;
 
 public interface UserDatabase {
-    void addUser(User user) throws SQLException;
+    void add(User user);
 
-    Collection<User> findAll() throws SQLException;
+    Collection<User> findAll();
 
-    Optional<User> findUserById(String userId);
+    Optional<User> findById(String userId);
 }

--- a/src/main/java/db/UserDatabaseH2.java
+++ b/src/main/java/db/UserDatabaseH2.java
@@ -14,10 +14,21 @@ import org.h2.util.JdbcUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * H2 데이터베이스를 사용하는 User 데이터베이스 클래스입니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public class UserDatabaseH2 implements UserDatabase {
     private static final Logger logger = LoggerFactory.getLogger(UserDatabaseH2.class);
     private final DataSource dataSource = DataSourceUtil.getDataSource();
 
+    /**
+     * 주어진 User 객체를 데이터베이스에 추가합니다.
+     *
+     * @param user 추가할 User 객체
+     */
     @Override
     public void add(User user) {
         String sql = "insert into users(user_id, password, name, email) values (?, ?, ?, ?)";
@@ -40,6 +51,12 @@ public class UserDatabaseH2 implements UserDatabase {
         }
     }
 
+    /**
+     * 주어진 사용자 ID에 해당하는 사용자를 데이터베이스에서 찾아 반환합니다.
+     *
+     * @param userId 찾을 사용자의 ID
+     * @return Optional<User> 객체
+     */
     @Override
     public Optional<User> findById(String userId) {
         String sql = "select * from users where user_id = ?";
@@ -65,6 +82,11 @@ public class UserDatabaseH2 implements UserDatabase {
         return Optional.empty();
     }
 
+    /**
+     * 데이터베이스에 저장된 모든 사용자를 반환합니다.
+     *
+     * @return 사용자 목록
+     */
     @Override
     public List<User> findAll() {
         String sql = "select * from users";
@@ -87,6 +109,11 @@ public class UserDatabaseH2 implements UserDatabase {
         return new ArrayList<>();
     }
 
+    /**
+     * 주어진 사용자 ID에 해당하는 사용자를 데이터베이스에서 삭제합니다.
+     *
+     * @param userId 삭제할 사용자의 ID
+     */
     @Override
     public void delete(String userId) {
         String sql = "delete from users where user_id = ?";
@@ -106,6 +133,13 @@ public class UserDatabaseH2 implements UserDatabase {
         }
     }
 
+    /**
+     * ResultSet에서 User 객체 목록을 생성합니다.
+     *
+     * @param rs ResultSet 객체
+     * @return User 객체 목록
+     * @throws SQLException SQL 예외 발생 시
+     */
     private List<User> makeUserList(ResultSet rs) throws SQLException {
         List<User> users = new ArrayList<>();
         while (rs.next()) {
@@ -115,6 +149,13 @@ public class UserDatabaseH2 implements UserDatabase {
         return users;
     }
 
+    /**
+     * ResultSet에서 User 객체로 변환합니다.
+     *
+     * @param rs ResultSet 객체
+     * @return User 객체
+     * @throws SQLException SQL 예외 발생 시
+     */
     private User convertToUser(ResultSet rs) throws SQLException {
         String userId = rs.getString("user_id");
         String password = rs.getString("password");
@@ -124,12 +165,25 @@ public class UserDatabaseH2 implements UserDatabase {
         return new User(userId, password, username, email);
     }
 
+    /**
+     * 데이터베이스 연결을 닫습니다.
+     *
+     * @param con  Connection 객체
+     * @param stmt Statement 객체
+     * @param rs   ResultSet 객체
+     */
     private void close(Connection con, Statement stmt, ResultSet rs) {
         JdbcUtils.closeSilently(con);
         JdbcUtils.closeSilently(stmt);
         JdbcUtils.closeSilently(rs);
     }
 
+    /**
+     * 데이터베이스 연결을 가져옵니다.
+     *
+     * @return Connection 객체
+     * @throws SQLException SQL 예외 발생 시
+     */
     private Connection getConnection() throws SQLException {
         Connection con = dataSource.getConnection();
         logger.debug("connection={}, class={}", con, con.getClass());

--- a/src/main/java/db/UserDatabaseH2.java
+++ b/src/main/java/db/UserDatabaseH2.java
@@ -1,0 +1,137 @@
+package db;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import javax.sql.DataSource;
+import model.User;
+import org.h2.util.JdbcUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UserDatabaseH2 implements UserDatabase {
+    private static final Logger logger = LoggerFactory.getLogger(UserDatabaseH2.class);
+    private final DataSource dataSource = DataSourceUtil.getDataSource();
+
+    @Override
+    public void add(User user) {
+        String sql = "insert into users(user_id, password, name, email) values (?, ?, ?, ?)";
+
+        Connection con = null;
+        PreparedStatement pstmt = null;
+
+        try {
+            con = getConnection();
+            pstmt = con.prepareStatement(sql);
+            pstmt.setString(1, user.getUserId());
+            pstmt.setString(2, user.getPassword());
+            pstmt.setString(3, user.getName());
+            pstmt.setString(4, user.getEmail());
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            logger.error("DB INSERT FAILED={}", e.getMessage());
+        } finally {
+            close(con, pstmt, null);
+        }
+    }
+
+    @Override
+    public Optional<User> findById(String userId) {
+        String sql = "select * from users where user_id = ?";
+
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+
+        try {
+            con = getConnection();
+            pstmt = con.prepareStatement(sql);
+            pstmt.setString(1, userId);
+            rs = pstmt.executeQuery();
+            if (rs.next()) {
+                User user = convertToUser(rs);
+                return Optional.of(user);
+            }
+        } catch (SQLException e) {
+            logger.error("DB SELECT FAILED={}", e.getMessage());
+        } finally {
+            close(con, pstmt, rs);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public List<User> findAll() {
+        String sql = "select * from users";
+
+        Connection con = null;
+        PreparedStatement pstmt = null;
+        ResultSet rs = null;
+
+        try {
+            con = getConnection();
+            pstmt = con.prepareStatement(sql);
+            rs = pstmt.executeQuery();
+
+            return makeUserList(rs);
+        } catch (SQLException e) {
+            logger.error("DB SELECT FAILED={}", e.getMessage());
+        } finally {
+            close(con, pstmt, rs);
+        }
+        return new ArrayList<>();
+    }
+
+    public void delete(String userId) {
+        String sql = "delete from users where user_id = ?";
+
+        Connection con = null;
+        PreparedStatement pstmt = null;
+
+        try {
+            con = getConnection();
+            pstmt = con.prepareStatement(sql);
+            pstmt.setString(1, userId);
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            logger.error("DB SELECT FAILED={}", e.getMessage());
+        } finally {
+            close(con, pstmt, null);
+        }
+    }
+
+    private List<User> makeUserList(ResultSet rs) throws SQLException {
+        List<User> users = new ArrayList<>();
+        while (rs.next()) {
+            User user = convertToUser(rs);
+            users.add(user);
+        }
+        return users;
+    }
+
+    private User convertToUser(ResultSet rs) throws SQLException {
+        String userId = rs.getString("user_id");
+        String password = rs.getString("password");
+        String username = rs.getString("name");
+        String email = rs.getString("email");
+
+        return new User(userId, password, username, email);
+    }
+
+    private void close(Connection con, Statement stmt, ResultSet rs) {
+        JdbcUtils.closeSilently(con);
+        JdbcUtils.closeSilently(stmt);
+        JdbcUtils.closeSilently(rs);
+    }
+
+    private Connection getConnection() throws SQLException {
+        Connection con = dataSource.getConnection();
+        logger.debug("connection={}, class={}", con, con.getClass());
+        return con;
+    }
+}

--- a/src/main/java/db/UserDatabaseH2.java
+++ b/src/main/java/db/UserDatabaseH2.java
@@ -87,6 +87,7 @@ public class UserDatabaseH2 implements UserDatabase {
         return new ArrayList<>();
     }
 
+    @Override
     public void delete(String userId) {
         String sql = "delete from users where user_id = ?";
 

--- a/src/main/java/db/UserDatabaseInMemory.java
+++ b/src/main/java/db/UserDatabaseInMemory.java
@@ -9,23 +9,48 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * 메모리 내부 데이터베이스를 사용하는 User 데이터베이스 클래스입니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public class UserDatabaseInMemory {
     private static final Logger logger = LoggerFactory.getLogger(UserDatabaseInMemory.class);
     private static final Map<String, User> users = new HashMap<>();
 
+    /**
+     * 주어진 User 객체를 데이터베이스에 추가합니다.
+     *
+     * @param user 추가할 User 객체
+     */
     public static void addUser(User user) {
         users.put(user.getUserId(), user);
         logger.debug("[Database] Success Add User !");
     }
 
+    /**
+     * 주어진 사용자 ID에 해당하는 사용자를 데이터베이스에서 찾아 반환합니다.
+     *
+     * @param userId 찾을 사용자의 ID
+     * @return Optional<User> 객체
+     */
     public static Optional<User> findUserById(String userId) {
         return Optional.ofNullable(users.get(userId));
     }
 
+    /**
+     * 데이터베이스에 저장된 모든 사용자를 반환합니다.
+     *
+     * @return 사용자 목록
+     */
     public static Collection<User> findAll() {
         return users.values().stream().toList();
     }
 
+    /**
+     * 데이터베이스의 모든 사용자를 삭제합니다.
+     */
     public static void clear() {
         users.clear();
     }

--- a/src/main/java/db/UserDatabaseInMemory.java
+++ b/src/main/java/db/UserDatabaseInMemory.java
@@ -9,8 +9,8 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class Database {
-    private static final Logger logger = LoggerFactory.getLogger(Database.class);
+public class UserDatabaseInMemory {
+    private static final Logger logger = LoggerFactory.getLogger(UserDatabaseInMemory.class);
     private static final Map<String, User> users = new HashMap<>();
 
     public static void addUser(User user) {

--- a/src/main/java/error/ResponseErrorUtil.java
+++ b/src/main/java/error/ResponseErrorUtil.java
@@ -4,11 +4,24 @@ import http.HttpResponse;
 import http.HttpStatus;
 import web.ErrorHtmlProcessor;
 
+/**
+ * 응답 오류 유틸리티 클래스는 응답을 전달할 때 발생하는 오류를 처리하는 데 사용됩니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public class ResponseErrorUtil {
 
     private ResponseErrorUtil() {
     }
 
+    /**
+     * 지정된 상태 코드로 응답을 전달하는 작업을 생성합니다.
+     *
+     * @param response 응답 객체
+     * @param status   HTTP 상태 코드
+     * @return 응답 오류를 처리하는 Runnable 작업
+     */
     public static Runnable forward(HttpResponse response, HttpStatus status) {
         return () -> new ErrorHtmlProcessor().responseError(response, status);
     }

--- a/src/main/java/error/ResponseErrorUtil.java
+++ b/src/main/java/error/ResponseErrorUtil.java
@@ -1,0 +1,15 @@
+package error;
+
+import http.HttpResponse;
+import http.HttpStatus;
+import web.ErrorHtmlProcessor;
+
+public class ResponseErrorUtil {
+
+    private ResponseErrorUtil() {
+    }
+
+    public static Runnable forward(HttpResponse response, HttpStatus status) {
+        return () -> new ErrorHtmlProcessor().responseError(response, status);
+    }
+}

--- a/src/main/java/http/Cookie.java
+++ b/src/main/java/http/Cookie.java
@@ -4,32 +4,69 @@ import static utils.HttpConstant.EQUAL;
 import static utils.HttpConstant.SP;
 import static utils.HttpConstant.SPLITTER;
 
+/**
+ * 쿠키 클래스는 HTTP 쿠키를 표현합니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public class Cookie {
 
     private final String cookieKey;
     private String cookieValue;
 
+    /**
+     * 주어진 쿠키 키와 값을 가지고 쿠키 객체를 생성합니다.
+     *
+     * @param cookieKey   쿠키 키
+     * @param cookieValue 쿠키 값
+     */
     public Cookie(String cookieKey, String cookieValue) {
         this.cookieKey = cookieKey;
         this.cookieValue = cookieValue + SPLITTER + SP;
     }
 
+    /**
+     * 쿠키의 경로를 설정합니다.
+     *
+     * @param path 경로
+     */
     public void setPath(String path) {
         cookieValue += "Path=" + path + SPLITTER + SP;
     }
 
+    /**
+     * 쿠키의 최대 수명을 설정합니다.
+     *
+     * @param maxAge 최대 수명
+     */
     public void setMaxAge(int maxAge) {
         cookieValue += "Max-Age=" + maxAge + SPLITTER + SP;
     }
 
+    /**
+     * 쿠키를 문자열로 반환합니다.
+     *
+     * @return 쿠키 문자열
+     */
     public String getCookie() {
         return cookieKey + EQUAL + cookieValue;
     }
 
+    /**
+     * 쿠키의 키를 반환합니다.
+     *
+     * @return 쿠키 키
+     */
     public String getCookieKey() {
         return cookieKey;
     }
 
+    /**
+     * 쿠키의 값만을 반환합니다.
+     *
+     * @return 쿠키 값
+     */
     public String getCookieValue() {
         return cookieValue;
     }

--- a/src/main/java/http/HttpRequest.java
+++ b/src/main/java/http/HttpRequest.java
@@ -2,7 +2,6 @@ package http;
 
 import static utils.HttpConstant.QUERY_PARAM_SYMBOL;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/http/HttpRequest.java
+++ b/src/main/java/http/HttpRequest.java
@@ -6,6 +6,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * HTTP 요청 클래스입니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public class HttpRequest {
     private final HttpMethod method;
     private final HttpRequestUri requestURI;
@@ -27,34 +33,77 @@ public class HttpRequest {
         this.parts = parts;
     }
 
+    /**
+     * HTTP 메소드를 반환합니다.
+     *
+     * @return HTTP 메소드
+     */
     public HttpMethod getMethod() {
         return method;
     }
 
+    /**
+     * 요청 URI를 반환합니다.
+     *
+     * @return 요청 URI
+     */
     public String getRequestURI() {
         return requestURI.uri();
     }
 
+    /**
+     * URI에서 쿼리 파라미터를 제외한 경로를 반환합니다.
+     *
+     * @return 경로
+     */
     public String getPath() {
         return requestURI.uri().split(QUERY_PARAM_SYMBOL)[0]; // 쿼리 파라미터를 제외한 부분
     }
 
+    /**
+     * HTTP 버전을 반환합니다.
+     *
+     * @return HTTP 버전
+     */
     public String getHttpVersion() {
         return httpVersion.version();
     }
 
+    /**
+     * 특정 헤더의 값을 반환합니다.
+     *
+     * @param headerName 헤더 이름
+     * @return 헤더 값
+     */
     public String getHeader(String headerName) {
         return headers.getOrDefault(headerName, "");
     }
 
+    /**
+     * 특정 파라미터의 값을 반환합니다.
+     *
+     * @param parameterName 파라미터 이름
+     * @return 파라미터 값
+     */
     public String getParameter(String parameterName) {
         return parameter.getOrDefault(parameterName, "");
     }
 
+    /**
+     * 쿠키 리스트를 반환합니다.
+     *
+     * @return 쿠키 리스트 (수정 불가능)
+     */
     public List<Cookie> getCookie() {
         return Collections.unmodifiableList(cookies);
     }
 
+    /**
+     * 멀티파트 요청 중 특정 파트를 반환합니다.
+     *
+     * @param partName 파트 이름
+     * @return 멀티파트 객체
+     */
     public MultiPart getPart(String partName) {
         return parts.stream()
                 .filter(part -> part.name.equals(partName))
@@ -62,6 +111,9 @@ public class HttpRequest {
                 .orElse(null);
     }
 
+    /**
+     * HTTP 요청 메소드 열거형입니다.
+     */
     public enum HttpMethod {
         GET("GET"),
         POST("POST");
@@ -73,12 +125,21 @@ public class HttpRequest {
         }
     }
 
+    /**
+     * HTTP 요청 URI를 표현하는 불변 레코드 클래스입니다.
+     */
     public record HttpRequestUri(String uri) {
     }
 
+    /**
+     * HTTP 버전을 표현하는 불변 레코드 클래스입니다.
+     */
     public record HttpVersion(String version) {
     }
 
+    /**
+     * 멀티파트를 표현하는 불변 레코드 클래스입니다.
+     */
     public record MultiPart(String name, String submittedFileName, String contentType, byte[] partBody) {
 
         @Override

--- a/src/main/java/http/HttpRequestBuilder.java
+++ b/src/main/java/http/HttpRequestBuilder.java
@@ -9,6 +9,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * HTTP 요청 빌더 클래스입니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public class HttpRequestBuilder {
     private HttpMethod method;
     private HttpRequestUri requestURI;
@@ -18,42 +24,89 @@ public class HttpRequestBuilder {
     private List<Cookie> cookies = new ArrayList<>();
     private List<MultiPart> parts = new ArrayList<>();
 
+    /**
+     * HTTP 요청 객체를 생성하여 반환합니다.
+     *
+     * @return HTTP 요청 객체
+     */
     public HttpRequest build() {
         return new HttpRequest(
                 method, requestURI, httpVersion, headers, parameter, cookies, parts
         );
     }
 
+    /**
+     * HTTP 요청 메소드를 설정합니다.
+     *
+     * @param method HTTP 요청 메소드
+     * @return 현재 HttpRequestBuilder 객체
+     */
     public HttpRequestBuilder setMethod(HttpMethod method) {
         this.method = method;
         return this;
     }
 
+    /**
+     * HTTP 요청 URI를 설정합니다.
+     *
+     * @param requestURI HTTP 요청 URI
+     * @return 현재 HttpRequestBuilder 객체
+     */
     public HttpRequestBuilder setRequestURI(HttpRequestUri requestURI) {
         this.requestURI = requestURI;
         return this;
     }
 
+    /**
+     * HTTP 버전을 설정합니다.
+     *
+     * @param httpVersion HTTP 버전
+     * @return 현재 HttpRequestBuilder 객체
+     */
     public HttpRequestBuilder setHttpVersion(HttpVersion httpVersion) {
         this.httpVersion = httpVersion;
         return this;
     }
 
+    /**
+     * HTTP 헤더를 설정합니다.
+     *
+     * @param headers HTTP 헤더 맵
+     * @return 현재 HttpRequestBuilder 객체
+     */
     public HttpRequestBuilder setHeaders(Map<String, String> headers) {
         this.headers = headers;
         return this;
     }
 
+    /**
+     * HTTP 요청 파라미터를 설정합니다.
+     *
+     * @param parameter HTTP 요청 파라미터 맵
+     * @return 현재 HttpRequestBuilder 객체
+     */
     public HttpRequestBuilder setParameter(Map<String, String> parameter) {
         this.parameter = parameter;
         return this;
     }
 
+    /**
+     * 쿠키를 설정합니다.
+     *
+     * @param cookies 쿠키 리스트
+     * @return 현재 HttpRequestBuilder 객체
+     */
     public HttpRequestBuilder setCookies(List<Cookie> cookies) {
         this.cookies = cookies;
         return this;
     }
 
+    /**
+     * 멀티파트를 설정합니다.
+     *
+     * @param parts 멀티파트 리스트
+     * @return 현재 HttpRequestBuilder 객체
+     */
     public HttpRequestBuilder setParts(List<MultiPart> parts) {
         this.parts = parts;
         return this;

--- a/src/main/java/http/HttpResponse.java
+++ b/src/main/java/http/HttpResponse.java
@@ -12,6 +12,15 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * HTTP 응답 클래스입니다.
+ * 이 클래스는 HTTP 응답을 생성하고 보낼 때 사용됩니다.
+ * 응답 헤더 및 바디를 설정하고, 클라이언트로 응답을 보내는 메서드를 제공합니다.
+ * 또한 쿠키를 추가하거나 리다이렉트를 설정하는 등의 기능을 지원합니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public class HttpResponse {
     private static final Logger logger = LoggerFactory.getLogger(HttpResponse.class);
     private String contentType = "Content-Type: ";
@@ -21,49 +30,102 @@ public class HttpResponse {
     private String location = "Location: ";
     private final DataOutputStream dos;
 
+    /**
+     * HttpResponse 객체를 생성합니다.
+     *
+     * @param dos DataOutputStream 객체
+     */
     public HttpResponse(DataOutputStream dos) {
         this.dos = dos;
     }
 
+    /**
+     * HTTP 버전을 설정합니다.
+     *
+     * @param httpVersion HTTP 버전
+     * @return HttpResponse 객체
+     */
     public HttpResponse setHttpVersion(String httpVersion) {
         writeString(httpVersion + SP);
         return this;
     }
 
+    /**
+     * 상태 코드를 설정합니다.
+     *
+     * @param status HttpStatus 객체
+     * @return HttpResponse 객체
+     */
     public HttpResponse setStatusCode(HttpStatus status) {
         writeString(status.code + SP + status.message + CRLF);
         return this;
     }
 
+    /**
+     * 컨텐츠 타입을 설정합니다.
+     *
+     * @param contentType 컨텐츠 타입
+     * @return HttpResponse 객체
+     */
     public HttpResponse setContentType(String contentType) {
         this.contentType += contentType;
         writeString(this.contentType + SPLITTER + SP);
         return this;
     }
 
+    /**
+     * 문자셋을 설정합니다.
+     *
+     * @param charset 문자셋
+     * @return HttpResponse 객체
+     */
     public HttpResponse setCharset(String charset) {
         this.charset += charset;
         writeString(this.charset + CRLF);
         return this;
     }
 
+    /**
+     * 컨텐츠 길이를 설정합니다.
+     *
+     * @param contentLength 컨텐츠 길이
+     * @return HttpResponse 객체
+     */
     public HttpResponse setContentLength(int contentLength) {
         this.contentLength += contentLength;
         writeString(this.contentLength + CRLF);
         return this;
     }
 
+    /**
+     * 마지막 수정 시간을 설정합니다.
+     *
+     * @param lastModified 마지막 수정 시간
+     * @return HttpResponse 객체
+     */
     public HttpResponse setLastModified(LocalDateTime lastModified) {
         this.lastModified += lastModified.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
         writeString(this.lastModified + CRLF);
         return this;
     }
 
+    /**
+     * 쿠키를 추가합니다.
+     *
+     * @param cookie Cookie 객체
+     * @return HttpResponse 객체
+     */
     public HttpResponse addCookie(Cookie cookie) {
         writeString("Set-Cookie: " + cookie.getCookie() + CRLF);
         return this;
     }
 
+    /**
+     * 쿠키 리스트 전체를 추가합니다.
+     *
+     * @param cookies 쿠키 목록
+     * @return HttpResponse 객체
+     */
     public HttpResponse addCookies(List<Cookie> cookies) {
         String cookieString = cookies.stream()
                 .map(Cookie::getCookie)
@@ -73,12 +135,24 @@ public class HttpResponse {
         return this;
     }
 
+    /**
+     * Location 값을 설정합니다.
+     *
+     * @param location 위치
+     * @return HttpResponse 객체
+     */
     public HttpResponse setLocation(String location) {
         this.location += location;
         writeString(this.location + CRLF);
         return this;
     }
 
+    /**
+     * 문자열 형태의 메시지 바디를 설정합니다.
+     *
+     * @param stringMessageBody 문자열 형태의 메시지 바디
+     * @return HttpResponse 객체
+     */
     public HttpResponse setMessageBody(String stringMessageBody) {
         writeString(CRLF);
         writeString(stringMessageBody);
@@ -86,6 +160,12 @@ public class HttpResponse {
         return this;
     }
 
+    /**
+     * 바이트 배열 형태의 메시지 바디를 설정합니다.
+     *
+     * @param bytesMessageBody 바이트 배열 형태의 메시지 바디
+     * @return HttpResponse 객체
+     */
     public HttpResponse setMessageBody(byte[] bytesMessageBody) {
         writeString(CRLF);
         writeBytes(bytesMessageBody);
@@ -93,6 +173,9 @@ public class HttpResponse {
         return this;
     }
 
+    /**
+     * 버퍼를 비웁니다.
+     */
     public void flush() {
         try {
             dos.flush();

--- a/src/main/java/http/HttpStatus.java
+++ b/src/main/java/http/HttpStatus.java
@@ -8,6 +8,7 @@ public enum HttpStatus {
     STATUS_FORBIDDEN(403, "Forbidden"),
     STATUS_NOT_FOUND(404, "Not Found"),
     STATUS_NOT_ALLOWED(405, "Method Not Allowed"),
+    INTERNAL_SERVER_ERROR(500, "Internal Server Error"),
     ;
 
     public final int code;

--- a/src/main/java/login/LoginManager.java
+++ b/src/main/java/login/LoginManager.java
@@ -1,6 +1,6 @@
 package login;
 
-import db.Database;
+import db.UserDatabaseInMemory;
 import java.util.Optional;
 import model.User;
 import org.slf4j.Logger;
@@ -10,7 +10,7 @@ public class LoginManager {
     private static final Logger logger = LoggerFactory.getLogger(LoginManager.class);
 
     public Optional<User> login(String id, String password) {
-        Optional<User> optionalUser = Database.findUserById(id);
+        Optional<User> optionalUser = UserDatabaseInMemory.findUserById(id);
 
         /* 유저 아이디 검증 */
         if (optionalUser.isEmpty()) {

--- a/src/main/java/manager/ArticleManager.java
+++ b/src/main/java/manager/ArticleManager.java
@@ -1,0 +1,25 @@
+package manager;
+
+import db.ArticleDatabase;
+import db.ArticleDatabaseH2;
+import java.util.Optional;
+import model.Article;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ArticleManager {
+    private static final Logger logger = LoggerFactory.getLogger(ArticleManager.class);
+    private final ArticleDatabase articleDatabase = new ArticleDatabaseH2();
+
+    public Article addArticle(Article article) {
+        return articleDatabase.add(article);
+    }
+
+    public Optional<Article> findLatestArticle(String userId) {
+        return articleDatabase.findLatest(userId);
+    }
+
+    public Optional<Article> findArticleById(int articleId) {
+        return articleDatabase.findById(articleId);
+    }
+}

--- a/src/main/java/manager/ArticleManager.java
+++ b/src/main/java/manager/ArticleManager.java
@@ -7,18 +7,42 @@ import model.Article;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * 게시글 관리자 클래스입니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public class ArticleManager {
     private static final Logger logger = LoggerFactory.getLogger(ArticleManager.class);
     private final ArticleDatabase articleDatabase = new ArticleDatabaseH2();
 
+    /**
+     * 게시글을 추가합니다.
+     *
+     * @param article 추가할 게시글
+     * @return 추가된 게시글
+     */
     public Article addArticle(Article article) {
         return articleDatabase.add(article);
     }
 
+    /**
+     * 특정 사용자의 최신 게시글을 찾습니다.
+     *
+     * @param userId 사용자 ID
+     * @return 최신 게시글 (Optional)
+     */
     public Optional<Article> findLatestArticle(String userId) {
         return articleDatabase.findLatest(userId);
     }
 
+    /**
+     * 게시글 ID를 기반으로 게시글을 찾습니다.
+     *
+     * @param articleId 게시글 ID
+     * @return 해당 게시글 (Optional)
+     */
     public Optional<Article> findArticleById(int articleId) {
         return articleDatabase.findById(articleId);
     }

--- a/src/main/java/manager/UserManager.java
+++ b/src/main/java/manager/UserManager.java
@@ -1,6 +1,8 @@
 package manager;
 
-import db.UserDatabaseInMemory;
+import db.UserDatabase;
+import db.UserDatabaseH2;
+import java.util.Collection;
 import java.util.Optional;
 import model.User;
 import org.slf4j.Logger;
@@ -8,9 +10,30 @@ import org.slf4j.LoggerFactory;
 
 public class UserManager {
     private static final Logger logger = LoggerFactory.getLogger(UserManager.class);
+    private final UserDatabase userDatabase = new UserDatabaseH2();
+
+    public boolean join(User user) {
+        String id = user.getUserId();
+
+        if (!isExistId(id)) {
+            return false;
+        }
+
+        userDatabase.add(user);
+        return true;
+    }
+
+    private boolean isExistId(String id) {
+        Optional<User> optionalUser = userDatabase.findById(id);
+        if (optionalUser.isPresent()) {
+            logger.error("이미 가입된 회원 아이디 입니다.");
+            return false;
+        }
+        return true;
+    }
 
     public Optional<User> login(String id, String password) {
-        Optional<User> optionalUser = UserDatabaseInMemory.findUserById(id);
+        Optional<User> optionalUser = userDatabase.findById(id);
 
         /* 유저 아이디 검증 */
         if (optionalUser.isEmpty()) {
@@ -27,5 +50,13 @@ public class UserManager {
 
         /* 유저 반환 */
         return Optional.of(user);
+    }
+
+    public Collection<User> findAllUser() {
+        return userDatabase.findAll();
+    }
+
+    public void deleteUser(User user) {
+        userDatabase.delete(user.getUserId());
     }
 }

--- a/src/main/java/manager/UserManager.java
+++ b/src/main/java/manager/UserManager.java
@@ -8,10 +8,22 @@ import model.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * 사용자 관리자 클래스입니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public class UserManager {
     private static final Logger logger = LoggerFactory.getLogger(UserManager.class);
     private final UserDatabase userDatabase = new UserDatabaseH2();
 
+    /**
+     * 사용자를 회원가입합니다.
+     *
+     * @param user 회원가입할 사용자 정보
+     * @return 회원가입이 성공하면 true, 실패하면 false를 반환합니다.
+     */
     public boolean join(User user) {
         String id = user.getUserId();
 
@@ -32,6 +44,13 @@ public class UserManager {
         return true;
     }
 
+    /**
+     * 사용자 로그인을 처리합니다.
+     *
+     * @param id       사용자 아이디
+     * @param password 사용자 비밀번호
+     * @return 로그인이 성공하면 해당 사용자 정보를, 실패하면 빈 Optional을 반환합니다.
+     */
     public Optional<User> login(String id, String password) {
         Optional<User> optionalUser = userDatabase.findById(id);
 
@@ -52,10 +71,20 @@ public class UserManager {
         return Optional.of(user);
     }
 
+    /**
+     * 모든 사용자를 조회합니다.
+     *
+     * @return 모든 사용자 정보를 담은 Collection
+     */
     public Collection<User> findAllUser() {
         return userDatabase.findAll();
     }
 
+    /**
+     * 사용자를 삭제합니다.
+     *
+     * @param user 삭제할 사용자
+     */
     public void deleteUser(User user) {
         userDatabase.delete(user.getUserId());
     }

--- a/src/main/java/manager/UserManager.java
+++ b/src/main/java/manager/UserManager.java
@@ -1,4 +1,4 @@
-package login;
+package manager;
 
 import db.UserDatabaseInMemory;
 import java.util.Optional;
@@ -6,8 +6,8 @@ import model.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class LoginManager {
-    private static final Logger logger = LoggerFactory.getLogger(LoginManager.class);
+public class UserManager {
+    private static final Logger logger = LoggerFactory.getLogger(UserManager.class);
 
     public Optional<User> login(String id, String password) {
         Optional<User> optionalUser = UserDatabaseInMemory.findUserById(id);

--- a/src/main/java/model/Article.java
+++ b/src/main/java/model/Article.java
@@ -3,6 +3,12 @@ package model;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
+/**
+ * 게시글 정보를 나타내는 클래스입니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public final class Article {
     private long id;
     private final String body;
@@ -10,30 +16,62 @@ public final class Article {
     private final LocalDateTime createdAt;
     private final String imagePath;
 
+    /**
+     * 게시글을 초기화하는 생성자입니다.
+     *
+     * @param body       본문
+     * @param createdBy  작성자 아이디
+     * @param createdAt  작성일시
+     * @param imagePath  이미지 경로
+     */
     public Article(String body, String createdBy, LocalDateTime createdAt, String imagePath) {
-        this.id = id;
         this.body = body;
         this.createdBy = createdBy;
         this.createdAt = createdAt;
         this.imagePath = imagePath;
     }
 
+    /**
+     * 게시글 ID를 반환합니다.
+     *
+     * @return 게시글 ID
+     */
     public long id() {
         return id;
     }
 
+    /**
+     * 본문을 반환합니다.
+     *
+     * @return 본문
+     */
     public String body() {
         return body;
     }
 
+    /**
+     * 작성자 아이디를 반환합니다.
+     *
+     * @return 작성자 아이디
+     */
     public String createdBy() {
         return createdBy;
     }
 
+    /**
+     * 작성일시를 반환합니다.
+     *
+     * @return 작성일시
+     */
     public LocalDateTime createdAt() {
         return createdAt;
     }
 
+    /**
+     * 이미지 경로를 반환합니다.
+     *
+     * @return 이미지 경로
+     */
     public String imagePath() {
         return imagePath;
     }
@@ -65,14 +103,31 @@ public final class Article {
                 '}';
     }
 
+    /**
+     * 특정 사용자가 게시글을 작성한 것인지 여부를 확인합니다.
+     *
+     * @param userId 사용자 ID
+     * @return 작성자인 경우 true, 아닌 경우 false를 반환합니다.
+     */
     public boolean isCreatedBy(String userId) {
         return createdBy.equals(userId);
     }
 
+    /**
+     * 게시글에 이미지가 포함되어 있는지 여부를 확인합니다.
+     *
+     * @return 이미지가 포함되어 있는 경우 true, 아닌 경우 false를 반환합니다.
+     */
     public boolean isImageExist() {
         return imagePath != null && !imagePath.isEmpty();
     }
 
+    /**
+     * 게시글 ID를 설정합니다.
+     *
+     * @param id 게시글 ID
+     * @return 현재 Article 객체를 반환합니다.
+     */
     public Article setId(long id) {
         this.id = id;
         return this;

--- a/src/main/java/model/Article.java
+++ b/src/main/java/model/Article.java
@@ -4,16 +4,22 @@ import java.time.LocalDateTime;
 import java.util.Objects;
 
 public final class Article {
+    private long id;
     private final String body;
     private final String createdBy; // 작성자 아이디
     private final LocalDateTime createdAt;
     private final String imagePath;
 
     public Article(String body, String createdBy, LocalDateTime createdAt, String imagePath) {
+        this.id = id;
         this.body = body;
         this.createdBy = createdBy;
         this.createdAt = createdAt;
         this.imagePath = imagePath;
+    }
+
+    public long id() {
+        return id;
     }
 
     public String body() {
@@ -65,5 +71,10 @@ public final class Article {
 
     public boolean isImageExist() {
         return imagePath != null && !imagePath.isEmpty();
+    }
+
+    public Article setId(long id) {
+        this.id = id;
+        return this;
     }
 }

--- a/src/main/java/model/User.java
+++ b/src/main/java/model/User.java
@@ -2,12 +2,25 @@ package model;
 
 import java.util.Objects;
 
+/**
+ * 사용자 정보를 나타내는 클래스입니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public class User {
     private String userId;
     private String password;
     private String name;
     private String email;
 
+    /**
+     * 사용자 정보를 초기화하는 생성자입니다.
+     * @param userId 사용자 ID
+     * @param password 비밀번호
+     * @param name 이름
+     * @param email 이메일
+     */
     public User(String userId, String password, String name, String email) {
         this.userId = userId;
         this.password = password;
@@ -15,18 +28,34 @@ public class User {
         this.email = email;
     }
 
+    /**
+     * 사용자 ID를 반환합니다.
+     * @return 사용자 ID
+     */
     public String getUserId() {
         return userId;
     }
 
+    /**
+     * 비밀번호를 반환합니다.
+     * @return 비밀번호
+     */
     public String getPassword() {
         return password;
     }
 
+    /**
+     * 사용자 이름을 반환합니다.
+     * @return 사용자 이름
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * 이메일을 반환합니다.
+     * @return 이메일
+     */
     public String getEmail() {
         return email;
     }

--- a/src/main/java/session/SessionManager.java
+++ b/src/main/java/session/SessionManager.java
@@ -11,33 +11,66 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import utils.HttpConstant;
 
+/**
+ * 세션을 관리하는 클래스입니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public class SessionManager {
     private static final Logger logger = LoggerFactory.getLogger(SessionManager.class);
     private static final Map<String, SessionUser> session = new ConcurrentHashMap<>();
 
+    /**
+     * 세션을 생성합니다.
+     * @return 생성된 세션 ID
+     */
     public String createSession() {
         logger.debug("[SESSION MANAGER] create session");
         return UUID.randomUUID().toString();
     }
 
+    /**
+     * 세션에 사용자를 등록합니다.
+     * @param sessionId 세션 ID
+     * @param user 사용자 정보
+     */
     public void enroll(String sessionId, User user) {
         logger.debug("[SESSION MANAGER] register");
         session.put(sessionId, new SessionUser(user.getUserId(), user.getName(), user.getEmail()));
     }
 
+    /**
+     * 주어진 세션 ID에 해당하는 세션을 반환합니다.
+     * @param sessionId 세션 ID
+     * @return 세션 사용자 정보(Optional)
+     */
     public Optional<SessionUser> getSession(String sessionId) {
         logger.debug("[SESSION MANAGER] get session = {}", sessionId);
         return Optional.ofNullable(session.get(sessionId));
     }
 
+    /**
+     * 주어진 세션 ID에 해당하는 세션을 삭제합니다.
+     * @param sessionId 세션 ID
+     */
     public void delete(String sessionId) {
         session.remove(sessionId);
     }
 
+    /**
+     * 모든 세션을 삭제합니다.
+     */
     public void clear() {
         session.clear();
     }
 
+    /**
+     * 주어진 쿠키에서 세션 ID를 찾아 반환합니다.
+     * @param cookies 쿠키 목록
+     * @param sessionKey 세션 키
+     * @return 세션 ID
+     */
     public String findSessionId(List<Cookie> cookies, String sessionKey) {
         return cookies.stream()
                 .filter(cookie -> cookie.getCookieKey().equals(sessionKey))
@@ -51,6 +84,9 @@ public class SessionManager {
         return sessionId.replace(HttpConstant.SPLITTER, "").trim();
     }
 
+    /**
+     * 세션 사용자 정보를 나타내는 불변 레코드입니다.
+     */
     public record SessionUser(String id, String name, String email) {
     }
 }

--- a/src/main/java/utils/HttpRequestConverter.java
+++ b/src/main/java/utils/HttpRequestConverter.java
@@ -22,6 +22,12 @@ import java.util.function.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * HTTP 요청을 HttpRequest 객체로 변환하는 유틸리티 클래스입니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public class HttpRequestConverter {
     private static final Logger logger = LoggerFactory.getLogger(HttpRequestConverter.class);
     private static final Predicate<String> CHECK_ALL_CONTENT_RECEIVED = request -> parseRequestBody(request).length()
@@ -29,6 +35,11 @@ public class HttpRequestConverter {
     private static final Predicate<String> CHECK_END_OF_BOUNDARY = request -> request.endsWith("--" + CRLF);
     private static final HttpRequestBuilder REQUEST_BUILDER = new HttpRequestBuilder();
 
+    /**
+     * InputStream으로부터 받은 데이터를 기반으로 HttpRequest 객체로 변환합니다.
+     * @param in InputStream 객체
+     * @return HttpRequest 객체
+     */
     public static HttpRequest convertToHttpRequest(InputStream in) {
         try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
             /* request 전부 읽기 */

--- a/src/main/java/utils/HttpRequestParser.java
+++ b/src/main/java/utils/HttpRequestParser.java
@@ -14,6 +14,12 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * HTTP 요청을 파싱하는 유틸리티 클래스입니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public enum HttpRequestParser {
     REQUEST_LINE(Pattern.compile("(?s)(^GET|^POST) (/.*?)\\s(HTTP/.{1,3})")),
     METHOD(Pattern.compile("(?s)(^GET|^POST)")),
@@ -33,6 +39,11 @@ public enum HttpRequestParser {
         this.compiledPattern = compiledPattern;
     }
 
+    /**
+     * HTTP 요청 라인을 파싱합니다.
+     * @param header HTTP 헤더
+     * @return HTTP 요청 라인
+     */
     public static String parseRequestLine(String header) {
         Matcher requestLineMatcher = REQUEST_LINE.compiledPattern.matcher(header);
         if (requestLineMatcher.find()) {
@@ -41,6 +52,11 @@ public enum HttpRequestParser {
         return "";
     }
 
+    /**
+     * HTTP 요청 메서드를 파싱합니다.
+     * @param httpMessage HTTP 메시지
+     * @return HTTP 요청 메서드
+     */
     public static HttpMethod parseMethod(String httpMessage) {
         Matcher methodMatcher = METHOD.compiledPattern.matcher(httpMessage);
         if (methodMatcher.find()) {
@@ -49,6 +65,11 @@ public enum HttpRequestParser {
         return HttpMethod.GET;
     }
 
+    /**
+     * HTTP 요청 URI를 파싱합니다.
+     * @param httpMessage HTTP 메시지
+     * @return HTTP 요청 URI
+     */
     public static HttpRequestUri parseUri(String httpMessage) {
         Matcher uriMatcher = URI.compiledPattern.matcher(httpMessage);
         if (uriMatcher.find()) {
@@ -57,6 +78,11 @@ public enum HttpRequestParser {
         return new HttpRequestUri("/");
     }
 
+    /**
+     * HTTP 요청 프로토콜 버전을 파싱합니다.
+     * @param httpMessage HTTP 메시지
+     * @return HTTP 요청 프로토콜 버전
+     */
     public static HttpVersion parseVersion(String httpMessage) {
         Matcher versionMatcher = VERSION.compiledPattern.matcher(httpMessage);
         if (versionMatcher.find()) {
@@ -65,6 +91,11 @@ public enum HttpRequestParser {
         return new HttpVersion("HTTP/1.1");
     }
 
+    /**
+     * HTTP 헤더를 파싱합니다.
+     * @param header HTTP 헤더
+     * @return 파싱된 HTTP 헤더 맵
+     */
     public static Map<String, String> parseHeader(String header) {
         Map<String, String> headers = new HashMap<>();
 
@@ -75,6 +106,11 @@ public enum HttpRequestParser {
         return Collections.unmodifiableMap(headers);
     }
 
+    /**
+     * 쿼리 파라미터를 파싱합니다.
+     * @param header HTTP 헤더
+     * @return 파싱된 쿼리 파라미터 맵
+     */
     public static Map<String, String> parseParams(String header) {
         Map<String, String> paramMap = new HashMap<>();
 
@@ -86,10 +122,9 @@ public enum HttpRequestParser {
     }
 
     /**
-     * Content-Length의 값을 파싱한다. 찾지 못하면 0을 반환한다.
-     *
-     * @param httpMessage HTTP Message
-     * @return Content-Length 값. 찾지 못하면 0을 반환한다.
+     * Content-Length 헤더의 값을 파싱합니다.
+     * @param httpMessage HTTP 메시지
+     * @return Content-Length 값
      */
     public static int parseContentLength(String httpMessage) {
         Matcher lengthMatcher = CONTENT_LENGTH.compiledPattern.matcher(httpMessage);
@@ -100,10 +135,9 @@ public enum HttpRequestParser {
     }
 
     /**
-     * Request Message를 파싱한다. 찾지 못하면 빈 문자열("")을 반환한다.
-     *
-     * @param httpMessage HTTP Message
-     * @return 문자열 Request Message를 반환한다.
+     * HTTP 요청 메시지를 파싱합니다.
+     * @param httpMessage HTTP 메시지
+     * @return HTTP 요청 메시지
      */
     public static String parseRequestBody(String httpMessage) {
         Matcher messageMatcher = REQUEST_MESSAGE.compiledPattern.matcher(httpMessage);
@@ -114,12 +148,12 @@ public enum HttpRequestParser {
     }
 
     /**
-     * HTTP 메시지에서 Content-Type이 multipart인 부분을 파싱하여 MultiPart 객체의 리스트를 반환한다.
-     * 이미지 파일은 MultiPart 객체의 contentType에 해당 확장자(ex. png, jpg, gif 등)를 입력한다.
-     * Encoding 형식은 ISO_8859_1 를 따른다.
+     * HTTP 메시지에서 Content-Type이 multipart인 부분을 파싱하여 MultiPart 객체의 리스트를 반환합니다.
+     * 이미지 파일은 MultiPart 객체의 contentType에 해당 확장자(ex. png, jpg, gif 등)를 입력합니다.
+     * Encoding 형식은 ISO_8859_1 를 따릅니다.
      *
      * @param httpMessage HTTP Message
-     * @return 파싱된 MultiPart 객체의 리스트. 발견된 MultiPart가 없을 경우 빈 리스트를 반환한다.
+     * @return 파싱된 MultiPart 객체의 리스트. 발견된 MultiPart가 없을 경우 빈 리스트를 반환합니다.
      */
     public static List<MultiPart> parseMultiPart(String httpMessage) {
         List<MultiPart> multiParts = new ArrayList<>();

--- a/src/main/java/utils/HttpResponseConverter.java
+++ b/src/main/java/utils/HttpResponseConverter.java
@@ -7,9 +7,21 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * HttpResponse 객체로의 변환을 담당하는 유틸리티 클래스입니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public class HttpResponseConverter {
     private static final Logger logger = LoggerFactory.getLogger(HttpResponseConverter.class);
 
+    /**
+     * OutputStream을 HttpResponse로 변환합니다.
+     * @param out OutputStream 객체
+     * @return HttpResponse 객체
+     * @throws IllegalStateException 변환 실패 시 발생하는 예외
+     */
     public static HttpResponse convertToHttpResponse(OutputStream out) {
         Optional<HttpResponse> response = Optional.of(new HttpResponse(new DataOutputStream(out)));
 

--- a/src/main/java/utils/ResourceHandler.java
+++ b/src/main/java/utils/ResourceHandler.java
@@ -22,6 +22,7 @@ public class ResourceHandler {
     public static final String STATIC_PATH = "/static";
     public static final String TEMPLATE_PATH = "/templates";
     public static final String MEDIA_PATH = "/media";
+    public static final String ERROR_PATH = BASE_PATH + STATIC_PATH + "/error";
     public static final String INDEX_HTML = "index.html";
     public static final int DEFAULT_BUFFER = 1024;
     public static final Map<String, String> FILE_EXTENSION_MAP = Map.of(

--- a/src/main/java/utils/ResourceHandler.java
+++ b/src/main/java/utils/ResourceHandler.java
@@ -16,6 +16,12 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * 정적 리소스를 처리하는 유틸리티 클래스입니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public class ResourceHandler {
     private static final Logger logger = LoggerFactory.getLogger(ResourceHandler.class);
     public static final String BASE_PATH = "./src/main/resources";
@@ -36,6 +42,12 @@ public class ResourceHandler {
             "svg", "image/svg+xml");
 
 
+    /**
+     * 정적 파일을 읽어옵니다.
+     *
+     * @param filePath 파일 경로
+     * @return 파일 내용을 바이트 배열로 반환합니다.
+     */
     public static byte[] read(String filePath) {
         File file = new File(filePath);
         byte[] byteArray = new byte[(int) file.length()]; // 파일의 크기만큼의 바이트 배열 생성
@@ -51,11 +63,11 @@ public class ResourceHandler {
     }
 
     /**
-     * 템플릿 파일을 읽어온다. 매개 변수가 디렉토리인 경우 해당 디렉토리의 'index.html' 파일을 읽는다. 파일 이름인 경우 해당 파일을 읽는다. 파일이 존재하지 않거나 읽을 수 없는 경우 빈
-     * 문자열("")을 반환한다.
+     * 템플릿 파일을 읽어옵니다. 매개 변수가 디렉토리인 경우 해당 디렉토리의 'index.html' 파일을 읽습니다. 파일 이름인 경우 해당 파일을 읽습니다.
+     * 파일이 존재하지 않거나 읽을 수 없는 경우 빈 문자열("")을 반환합니다.
      *
      * @param templateName 템플릿 파일의 경로 (디렉토리 또는 파일)
-     * @return 템플릿 파일의 내용을 문자열로 반환하며, 파일이 존재하지 않거나 읽을 수 없는 경우 빈 문자열("")을 반환한다.
+     * @return 템플릿 파일의 내용을 문자열로 반환하며, 파일이 존재하지 않거나 읽을 수 없는 경우 빈 문자열("")을 반환합니다.
      */
     public static String readTemplate(String templateName) {
         // 디렉토리인 경우 인덱스 파일 추가
@@ -74,6 +86,12 @@ public class ResourceHandler {
         return ""; // 파일이 존재하지 않거나 읽을 수 없는 경우 빈 문자열 반환
     }
 
+    /**
+     * 파일의 확장자를 반환합니다.
+     *
+     * @param uri 파일 경로
+     * @return 파일의 확장자를 반환합니다.
+     */
     public static String getExtension(String uri) {
         if (uri.contains(".")) {
             return uri.substring(uri.lastIndexOf(".") + 1);
@@ -81,6 +99,12 @@ public class ResourceHandler {
         return uri;
     }
 
+    /**
+     * 이미지를 저장합니다.
+     *
+     * @param multiPart MultiPart 객체
+     * @param savePath 저장 경로
+     */
     public static void saveImage(MultiPart multiPart, String savePath) {
         /* 출력 결과물 경로 : '/BASE_PATH/media/userId/filename' */
         File outputFile = new File(BASE_PATH, savePath);
@@ -104,6 +128,13 @@ public class ResourceHandler {
         }
     }
 
+    /**
+     * 디렉토리를 생성합니다.
+     *
+     * @param root 루트 경로
+     * @param path 생성할 디렉토리 경로
+     * @return 디렉토리가 성공적으로 생성되었는지 여부를 반환합니다.
+     */
     public static boolean createDirectory(String root, String path) {
         File directory = new File(root, path);
         if (!directory.exists()) {

--- a/src/main/java/web/ArticleWrite.java
+++ b/src/main/java/web/ArticleWrite.java
@@ -4,7 +4,7 @@ import static java.nio.charset.StandardCharsets.*;
 import static utils.HttpConstant.CRLF;
 import static utils.ResourceHandler.*;
 
-import db.ArticleDatabase;
+import db.ArticleDatabaseInMemory;
 import http.Cookie;
 import http.HttpRequest;
 import http.HttpRequest.HttpMethod;
@@ -60,7 +60,7 @@ public class ArticleWrite extends DynamicHtmlProcessor {
 
         // case 3: POST 요청 (로그인 o)
         Article article = createArticle(request, sessionUser.id());
-        ArticleDatabase.add(article);
+        ArticleDatabaseInMemory.add(article);
 
         responseHeader302(response, "/");
         response.setMessageBody(CRLF);

--- a/src/main/java/web/ArticleWrite.java
+++ b/src/main/java/web/ArticleWrite.java
@@ -24,10 +24,22 @@ import model.Article;
 import session.SessionManager;
 import session.SessionManager.SessionUser;
 
+/**
+ * 게시글 작성을 처리하는 클래스입니다.
+ * DynamicHtmlProcessor를 상속받아 게시글 작성 관련 기능을 구현합니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public class ArticleWrite extends DynamicHtmlProcessor {
     private final SessionManager sessionManager = new SessionManager();
     private final ArticleManager articleManager = new ArticleManager();
 
+    /**
+     * HTTP 요청을 처리합니다.
+     * @param request HTTP 요청 객체
+     * @param response HTTP 응답 객체
+     */
     @Override
     public void process(HttpRequest request, HttpResponse response) {
         List<Cookie> cookies = request.getCookie();
@@ -72,6 +84,12 @@ public class ArticleWrite extends DynamicHtmlProcessor {
         response.flush();
     }
 
+    /**
+     * 게시글을 생성합니다.
+     * @param request HTTP 요청 객체
+     * @param userId 사용자 ID
+     * @return 생성된 게시글 객체
+     */
     private Article createArticle(HttpRequest request, String userId) {
         MultiPart articlePart = request.getPart("article-body");
         MultiPart photoPart = request.getPart("photo");
@@ -90,6 +108,12 @@ public class ArticleWrite extends DynamicHtmlProcessor {
         return new Article(articleBody, userId, LocalDateTime.now(), savePath);
     }
 
+    /**
+     * 이미지 저장 경로를 생성합니다.
+     * @param photoPart MultiPart 객체
+     * @param userId 사용자 ID
+     * @return 이미지 저장 경로
+     */
     private String makeSavePath(MultiPart photoPart, String userId) {
         String imagePath = "";
         if (photoPart.submittedFileName() != null) {

--- a/src/main/java/web/DynamicHtmlProcessor.java
+++ b/src/main/java/web/DynamicHtmlProcessor.java
@@ -1,8 +1,11 @@
 package web;
 
+import error.ResponseErrorUtil;
 import http.Cookie;
 import http.HttpRequest;
+import http.HttpRequest.HttpMethod;
 import http.HttpResponse;
+import http.HttpStatus;
 import java.util.List;
 import java.util.Optional;
 import manager.ArticleManager;
@@ -19,6 +22,10 @@ public class DynamicHtmlProcessor extends HttpProcessor {
 
     @Override
     public void process(HttpRequest request, HttpResponse response) {
+        if (request.getMethod() == HttpMethod.POST) {
+            ResponseErrorUtil.forward(response, HttpStatus.STATUS_NOT_ALLOWED).run();
+        }
+
         List<Cookie> cookies = request.getCookie();
 
         /* 쿠키로부터 세션 아이디 가져오기 */

--- a/src/main/java/web/DynamicHtmlProcessor.java
+++ b/src/main/java/web/DynamicHtmlProcessor.java
@@ -14,12 +14,24 @@ import session.SessionManager;
 import session.SessionManager.SessionUser;
 import utils.ResourceHandler;
 
+/**
+ * 동적 HTML을 처리하는 클래스입니다.
+ * HttpProcessor를 상속받아 HTTP 요청에 따라 동적인 HTML을 생성합니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public class DynamicHtmlProcessor extends HttpProcessor {
 
     private final SessionManager sessionManager = new SessionManager();
     private final ArticleManager articleManager = new ArticleManager();
     public final StringBuilder htmlBuilder = new StringBuilder();
 
+    /**
+     * HTTP 요청을 처리합니다.
+     * @param request HTTP 요청 객체
+     * @param response HTTP 응답 객체
+     */
     @Override
     public void process(HttpRequest request, HttpResponse response) {
         if (request.getMethod() == HttpMethod.POST) {
@@ -57,15 +69,19 @@ public class DynamicHtmlProcessor extends HttpProcessor {
         response.flush();
     }
 
+    /**
+     * 템플릿 파일을 읽어옵니다.
+     * @param templateName 템플릿 파일 이름
+     * @return 템플릿 파일 내용
+     */
     public String readTemplate(String templateName) {
         return ResourceHandler.readTemplate(templateName);
     }
 
     /**
-     * HTML 문자열에서 주어진 시작 문자열(start)과 끝 문자열(end) 사이의 내용을 지우고, 대체할 새로운 템플릿(template)을 삽입한다.
-     *
-     * @param start    대체할 문자열의 시작 부분
-     * @param end      대체할 문자열의 마지막 부분
+     * HTML 문자열에서 주어진 시작 문자열(start)과 끝 문자열(end) 사이의 내용을 지우고, 대체할 새로운 템플릿(template)을 삽입합니다.
+     * @param start 대체할 문자열의 시작 부분
+     * @param end 대체할 문자열의 마지막 부분
      * @param template 대체할 새로운 템플릿 문자열
      */
     public void changeHtml(String start, String end, String template) {
@@ -73,6 +89,11 @@ public class DynamicHtmlProcessor extends HttpProcessor {
         htmlBuilder.insert(htmlBuilder.indexOf(start), template);
     }
 
+    /**
+     * 사용자 프로필을 생성합니다.
+     * @param userId 사용자 ID
+     * @return 사용자 프로필 HTML 문자열
+     */
     private String createUserProfile(String userId) {
         return String.format("""
                 <li class="header__menu__item">
@@ -90,6 +111,10 @@ public class DynamicHtmlProcessor extends HttpProcessor {
                 """, userId);
     }
 
+    /**
+     * 게시글에 이미지를 추가합니다.
+     * @param article 게시글 객체
+     */
     private void createImage(Article article) {
         if (article.isImageExist()) {
             changeHtml("<!-- target photo -->", "<!-- end photo -->",
@@ -97,6 +122,10 @@ public class DynamicHtmlProcessor extends HttpProcessor {
         }
     }
 
+    /**
+     * 게시글 본문을 추가합니다.
+     * @param article 게시글 객체
+     */
     private void createArticleBody(Article article) {
         changeHtml("<!-- target article -->", "<!-- end article -->", article.body());
     }

--- a/src/main/java/web/DynamicHtmlProcessor.java
+++ b/src/main/java/web/DynamicHtmlProcessor.java
@@ -1,11 +1,11 @@
 package web;
 
-import db.ArticleDatabaseInMemory;
 import http.Cookie;
 import http.HttpRequest;
 import http.HttpResponse;
 import java.util.List;
 import java.util.Optional;
+import manager.ArticleManager;
 import model.Article;
 import session.SessionManager;
 import session.SessionManager.SessionUser;
@@ -14,6 +14,7 @@ import utils.ResourceHandler;
 public class DynamicHtmlProcessor extends HttpProcessor {
 
     private final SessionManager sessionManager = new SessionManager();
+    private final ArticleManager articleManager = new ArticleManager();
     public final StringBuilder htmlBuilder = new StringBuilder();
 
     @Override
@@ -37,7 +38,7 @@ public class DynamicHtmlProcessor extends HttpProcessor {
             changeHtml("<!-- target user -->", "<!-- end user -->", userProfile);
 
             /* 작성한 게시글이 있으면 게시글 내용 입력 */
-            Optional<Article> optionalArticle = ArticleDatabaseInMemory.findLatest(user.id());
+            Optional<Article> optionalArticle = articleManager.findLatestArticle(user.id());
             optionalArticle.ifPresent(this::createImage);
             optionalArticle.ifPresent(this::createArticleBody);
         }
@@ -84,7 +85,8 @@ public class DynamicHtmlProcessor extends HttpProcessor {
 
     private void createImage(Article article) {
         if (article.isImageExist()) {
-            changeHtml("<!-- target photo -->", "<!-- end photo -->", "<img class=\"post__img\" src=\"" + article.imagePath() + "\"/>");
+            changeHtml("<!-- target photo -->", "<!-- end photo -->",
+                    "<img class=\"post__img\" src=\"" + article.imagePath() + "\"/>");
         }
     }
 

--- a/src/main/java/web/DynamicHtmlProcessor.java
+++ b/src/main/java/web/DynamicHtmlProcessor.java
@@ -1,6 +1,6 @@
 package web;
 
-import db.ArticleDatabase;
+import db.ArticleDatabaseInMemory;
 import http.Cookie;
 import http.HttpRequest;
 import http.HttpResponse;
@@ -37,7 +37,7 @@ public class DynamicHtmlProcessor extends HttpProcessor {
             changeHtml("<!-- target user -->", "<!-- end user -->", userProfile);
 
             /* 작성한 게시글이 있으면 게시글 내용 입력 */
-            Optional<Article> optionalArticle = ArticleDatabase.findLatest(user.id());
+            Optional<Article> optionalArticle = ArticleDatabaseInMemory.findLatest(user.id());
             optionalArticle.ifPresent(this::createImage);
             optionalArticle.ifPresent(this::createArticleBody);
         }

--- a/src/main/java/web/ErrorHtmlProcessor.java
+++ b/src/main/java/web/ErrorHtmlProcessor.java
@@ -1,0 +1,29 @@
+package web;
+
+import static utils.ResourceHandler.ERROR_PATH;
+import static utils.ResourceHandler.read;
+
+import http.HttpResponse;
+import http.HttpStatus;
+import java.io.File;
+
+public class ErrorHtmlProcessor extends HttpProcessor {
+
+    public void responseError(HttpResponse response, HttpStatus status) {
+        byte[] errorPage = read(ERROR_PATH + getErrorPagePath(status));
+        responseErrorHeader(response, status);
+        responseMessage(response, errorPage);
+        response.flush();
+    }
+
+    private String getErrorPagePath(HttpStatus status) {
+        return String.format(File.separator + "%d.html", status.code);
+    }
+
+    private void responseErrorHeader(HttpResponse response, HttpStatus status) {
+        response.setHttpVersion(BASIC_HTTP_VERSION)
+                .setStatusCode(status)
+                .setContentType("text/html")
+                .setCharset(BASIC_CHAR_SET);
+    }
+}

--- a/src/main/java/web/ErrorHtmlProcessor.java
+++ b/src/main/java/web/ErrorHtmlProcessor.java
@@ -7,8 +7,20 @@ import http.HttpResponse;
 import http.HttpStatus;
 import java.io.File;
 
+/**
+ * 에러 HTML 페이지를 처리하는 클래스입니다.
+ * HttpProcessor를 상속받아 HTTP 응답에 에러 페이지를 설정합니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public class ErrorHtmlProcessor extends HttpProcessor {
 
+    /**
+     * HTTP 응답에 에러 페이지를 설정합니다.
+     * @param response HTTP 응답 객체
+     * @param status HTTP 상태 코드
+     */
     public void responseError(HttpResponse response, HttpStatus status) {
         byte[] errorPage = read(ERROR_PATH + getErrorPagePath(status));
         responseErrorHeader(response, status);
@@ -16,10 +28,20 @@ public class ErrorHtmlProcessor extends HttpProcessor {
         response.flush();
     }
 
+    /**
+     * 에러 페이지의 파일 경로를 가져옵니다.
+     * @param status HTTP 상태 코드
+     * @return 에러 페이지의 파일 경로
+     */
     private String getErrorPagePath(HttpStatus status) {
         return String.format(File.separator + "%d.html", status.code);
     }
 
+    /**
+     * HTTP 응답에 에러 헤더를 설정합니다.
+     * @param response HTTP 응답 객체
+     * @param status HTTP 상태 코드
+     */
     private void responseErrorHeader(HttpResponse response, HttpStatus status) {
         response.setHttpVersion(BASIC_HTTP_VERSION)
                 .setStatusCode(status)

--- a/src/main/java/web/HttpProcessor.java
+++ b/src/main/java/web/HttpProcessor.java
@@ -6,14 +6,31 @@ import http.HttpRequest;
 import http.HttpResponse;
 import http.HttpStatus;
 
+/**
+ * HTTP 요청을 처리하는 추상 클래스입니다.
+ * Processor를 구현하고 있으며, 기본적인 HTTP 응답을 생성하는 메서드를 제공합니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public abstract class HttpProcessor implements Processor {
     public static final String BASIC_HTTP_VERSION = "HTTP/1.1";
     public static final String BASIC_CHAR_SET = "utf-8";
 
+    /**
+     * HTTP 요청을 처리합니다.
+     * @param request HTTP 요청 객체
+     * @param response HTTP 응답 객체
+     */
     @Override
     public void process(HttpRequest request, HttpResponse response) {
     }
 
+    /**
+     * HTTP 200 상태 코드를 포함한 응답 헤더를 설정합니다.
+     * @param response HTTP 응답 객체
+     * @param contentType 컨텐츠 타입
+     */
     public void responseHeader200(HttpResponse response, String contentType) {
         response.setHttpVersion(BASIC_HTTP_VERSION)
                 .setStatusCode(HttpStatus.STATUS_OK)
@@ -21,6 +38,11 @@ public abstract class HttpProcessor implements Processor {
                 .setCharset(BASIC_CHAR_SET);
     }
 
+    /**
+     * HTTP 302 상태 코드를 포함한 응답 헤더를 설정합니다.
+     * @param response HTTP 응답 객체
+     * @param location 리다이렉션 위치
+     */
     public void responseHeader302(HttpResponse response, String location) { // TODO: HttpResponse 에 sendRedirect() 만들기
         response.setHttpVersion(BASIC_HTTP_VERSION)
                 .setStatusCode(HttpStatus.STATUS_FOUND)
@@ -28,11 +50,21 @@ public abstract class HttpProcessor implements Processor {
                 .setCharset(BASIC_CHAR_SET);
     }
 
+    /**
+     * 바이트 배열 형태의 리소스를 응답 메시지에 설정합니다.
+     * @param response HTTP 응답 객체
+     * @param resource 바이트 배열 형태의 리소스
+     */
     public void responseMessage(HttpResponse response, byte[] resource) {
         response.setContentLength(resource.length)
                 .setMessageBody(resource);
     }
 
+    /**
+     * StringBuilder 형태의 문자열을 응답 메시지에 설정합니다.
+     * @param response HTTP 응답 객체
+     * @param builder StringBuilder 객체
+     */
     public void responseMessage(HttpResponse response, StringBuilder builder) {
         response.setContentLength(builder.toString().getBytes().length)
                 .setMessageBody(builder.toString());
@@ -40,6 +72,11 @@ public abstract class HttpProcessor implements Processor {
         builder.setLength(0); // StringBuilder 초기화
     }
 
+    /**
+     * HTTP 요청의 컨텐츠 타입을 가져옵니다.
+     * @param request HTTP 요청 객체
+     * @return 컨텐츠 타입
+     */
     public String getContentType(HttpRequest request) {
         String extension = getExtension(request.getRequestURI());
         return FILE_EXTENSION_MAP.getOrDefault(extension, "text/html");

--- a/src/main/java/web/MemberList.java
+++ b/src/main/java/web/MemberList.java
@@ -13,10 +13,25 @@ import model.User;
 import session.SessionManager;
 import session.SessionManager.SessionUser;
 
+/**
+ * 회원 목록을 처리하는 클래스입니다.
+ * DynamicHtmlProcessor를 상속받아 로그인된 사용자의 목록을 표시합니다.
+ * 세션이 없으면 로그인 페이지로 리다이렉션합니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public class MemberList extends DynamicHtmlProcessor {
     private final SessionManager sessionManager = new SessionManager();
     private final UserManager userManager = new UserManager();
 
+    /**
+     * HTTP 요청을 처리합니다.
+     * 세션이 없으면 로그인 페이지로 리다이렉션하고,
+     * 로그인된 사용자의 목록을 표시합니다.
+     * @param request HTTP 요청 객체
+     * @param response HTTP 응답 객체
+     */
     @Override
     public void process(HttpRequest request, HttpResponse response) {
         List<Cookie> cookies = request.getCookie();
@@ -50,6 +65,11 @@ public class MemberList extends DynamicHtmlProcessor {
         response.flush();
     }
 
+    /**
+     * User 객체 리스트를 HTML 테이블로 변환합니다.
+     * @param users User 객체 목록
+     * @return HTML 테이블 문자열
+     */
     private String createUserTable(Collection<User> users) {
         StringBuilder htmlBuilder = new StringBuilder();
 

--- a/src/main/java/web/MemberList.java
+++ b/src/main/java/web/MemberList.java
@@ -2,19 +2,20 @@ package web;
 
 import static utils.HttpConstant.CRLF;
 
-import db.UserDatabaseInMemory;
 import http.Cookie;
 import http.HttpRequest;
 import http.HttpResponse;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import manager.UserManager;
 import model.User;
 import session.SessionManager;
 import session.SessionManager.SessionUser;
 
 public class MemberList extends DynamicHtmlProcessor {
     private final SessionManager sessionManager = new SessionManager();
+    private final UserManager userManager = new UserManager();
 
     @Override
     public void process(HttpRequest request, HttpResponse response) {
@@ -40,7 +41,7 @@ public class MemberList extends DynamicHtmlProcessor {
 
         /* 가입된 User List 테이블 추가 */
         changeHtml("<!-- target user -->", "<!-- end user -->", userName);
-        changeHtml("<!-- target list -->", "<!-- end list -->", createUserTable(UserDatabaseInMemory.findAll()));
+        changeHtml("<!-- target list -->", "<!-- end list -->", createUserTable(userManager.findAllUser()));
 
         /* http response 작성 */
         responseHeader200(response, getContentType(request));

--- a/src/main/java/web/MemberList.java
+++ b/src/main/java/web/MemberList.java
@@ -2,7 +2,7 @@ package web;
 
 import static utils.HttpConstant.CRLF;
 
-import db.Database;
+import db.UserDatabaseInMemory;
 import http.Cookie;
 import http.HttpRequest;
 import http.HttpResponse;
@@ -40,7 +40,7 @@ public class MemberList extends DynamicHtmlProcessor {
 
         /* 가입된 User List 테이블 추가 */
         changeHtml("<!-- target user -->", "<!-- end user -->", userName);
-        changeHtml("<!-- target list -->", "<!-- end list -->", createUserTable(Database.findAll()));
+        changeHtml("<!-- target list -->", "<!-- end list -->", createUserTable(UserDatabaseInMemory.findAll()));
 
         /* http response 작성 */
         responseHeader200(response, getContentType(request));

--- a/src/main/java/web/MemberLogin.java
+++ b/src/main/java/web/MemberLogin.java
@@ -13,12 +13,29 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * 회원 로그인을 처리하는 클래스입니다.
+ * StaticHtmlProcessor를 상속받아 GET 요청일 때는 상위 클래스의 처리를 따르고,
+ * POST 요청일 때는 로그인을 수행합니다.
+ * 로그인이 실패하면 login-failed.html로 리다이렉션하고,
+ * 성공하면 index.html로 리다이렉션하며 세션을 생성하여 등록합니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public class MemberLogin extends StaticHtmlProcessor {
     private static final Logger logger = LoggerFactory.getLogger(MemberLogin.class);
     private static final String SESSION_NAME = "SID";
     private final UserManager userManager = new UserManager();
     private final SessionManager sessionManager = new SessionManager();
 
+    /**
+     * HTTP 요청을 처리합니다.
+     * GET 요청일 때는 상위 클래스의 처리를 따르고,
+     * POST 요청일 때는 로그인을 수행합니다.
+     * @param request HTTP 요청 객체
+     * @param response HTTP 응답 객체
+     */
     @Override
     public void process(HttpRequest request, HttpResponse response) {
         if (request.getMethod().equals(HttpMethod.GET)) {

--- a/src/main/java/web/MemberLogin.java
+++ b/src/main/java/web/MemberLogin.java
@@ -7,7 +7,7 @@ import http.Cookie;
 import http.HttpRequest;
 import http.HttpResponse;
 import model.User;
-import login.LoginManager;
+import manager.UserManager;
 import session.SessionManager;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 public class MemberLogin extends StaticHtmlProcessor {
     private static final Logger logger = LoggerFactory.getLogger(MemberLogin.class);
     private static final String SESSION_NAME = "SID";
-    private final LoginManager loginManager = new LoginManager();
+    private final UserManager userManager = new UserManager();
     private final SessionManager sessionManager = new SessionManager();
 
     @Override
@@ -29,7 +29,7 @@ public class MemberLogin extends StaticHtmlProcessor {
         String id = request.getParameter("id");
         String password = request.getParameter("password");
 
-        Optional<User> optionalUser = loginManager.login(id, password);
+        Optional<User> optionalUser = userManager.login(id, password);
 
         /* 로그인 실패: login-failed.html 리다이렉션 */
         if (optionalUser.isEmpty()) {

--- a/src/main/java/web/MemberLogout.java
+++ b/src/main/java/web/MemberLogout.java
@@ -10,10 +10,26 @@ import java.util.Optional;
 import session.SessionManager;
 import session.SessionManager.SessionUser;
 
+/**
+ * 회원 로그아웃을 처리하는 클래스입니다.
+ * StaticHtmlProcessor를 상속받아 사용자의 세션을 종료하고 로그아웃을 수행합니다.
+ * 현재 세션을 확인하여 세션이 존재하지 않으면 루트('/')로 리다이렉션하고,
+ * 세션이 존재하면 세션을 제거하고 쿠키를 만료시킨 후 루트('/')로 리다이렉션합니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public class MemberLogout extends StaticHtmlProcessor {
     private static final String SESSION_NAME = "SID";
     private final SessionManager sessionManager = new SessionManager();
 
+    /**
+     * HTTP 요청을 처리합니다.
+     * 현재 세션을 확인하여 세션이 존재하지 않으면 루트('/')로 리다이렉션하고,
+     * 세션이 존재하면 세션을 제거하고 쿠키를 만료시킨 후 루트('/')로 리다이렉션합니다.
+     * @param request HTTP 요청 객체
+     * @param response HTTP 응답 객체
+     */
     @Override
     public void process(HttpRequest request, HttpResponse response) {
         List<Cookie> cookies = request.getCookie();

--- a/src/main/java/web/MemberSave.java
+++ b/src/main/java/web/MemberSave.java
@@ -6,23 +6,22 @@ import static utils.HttpConstant.CRLF;
 import http.HttpRequest;
 import http.HttpRequest.HttpMethod;
 import http.HttpResponse;
+import java.util.function.Function;
+import manager.UserManager;
 import model.User;
 
 public class MemberSave extends StaticHtmlProcessor {
     private final UserManager userManager = new UserManager();
+    private static final Function<Boolean, String> REDIRECT = isSuccess -> isSuccess ? "/" : "/registration/failed.html";
 
     @Override
     public void process(HttpRequest request, HttpResponse response) {
         if (request.getMethod() == HttpMethod.POST) {
-            UserDatabaseInMemory.addUser(createUser(request));
-
-            responseHeader302(response, "/");
-            response.setMessageBody(CRLF);
-
-            response.flush();
             User user = createUser(request);
+            view(response, userManager.join(user));
             return;
         }
+
         super.process(request, response);
     }
 
@@ -33,5 +32,12 @@ public class MemberSave extends StaticHtmlProcessor {
         String password = request.getParameter("password");
 
         return new User(id, password, username, email);
+    }
+
+    private void view(HttpResponse response, boolean successJoin) {
+        responseHeader302(response, REDIRECT.apply(successJoin));
+        response.setMessageBody(CRLF);
+
+        response.flush();
     }
 }

--- a/src/main/java/web/MemberSave.java
+++ b/src/main/java/web/MemberSave.java
@@ -3,7 +3,6 @@ package web;
 
 import static utils.HttpConstant.CRLF;
 
-import db.UserDatabaseInMemory;
 import http.HttpRequest;
 import http.HttpRequest.HttpMethod;
 import http.HttpResponse;

--- a/src/main/java/web/MemberSave.java
+++ b/src/main/java/web/MemberSave.java
@@ -9,6 +9,7 @@ import http.HttpResponse;
 import model.User;
 
 public class MemberSave extends StaticHtmlProcessor {
+    private final UserManager userManager = new UserManager();
 
     @Override
     public void process(HttpRequest request, HttpResponse response) {
@@ -19,6 +20,7 @@ public class MemberSave extends StaticHtmlProcessor {
             response.setMessageBody(CRLF);
 
             response.flush();
+            User user = createUser(request);
             return;
         }
         super.process(request, response);

--- a/src/main/java/web/MemberSave.java
+++ b/src/main/java/web/MemberSave.java
@@ -10,10 +10,24 @@ import java.util.function.Function;
 import manager.UserManager;
 import model.User;
 
+/**
+ * 회원가입을 처리하는 클래스입니다.
+ * StaticHtmlProcessor를 상속받아 POST 메서드로 요청이 오면 회원 정보를 생성하고 회원가입을 수행합니다.
+ * 회원가입에 성공하면 "/"으로 리다이렉트하고, 실패하면 "/registration/failed.html"로 리다이렉트합니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public class MemberSave extends StaticHtmlProcessor {
     private final UserManager userManager = new UserManager();
     private static final Function<Boolean, String> REDIRECT = isSuccess -> isSuccess ? "/" : "/registration/failed.html";
 
+    /**
+     * HTTP 요청을 처리합니다.
+     * POST 메서드로 요청이 오면 회원 정보를 생성하고 회원가입을 수행합니다.
+     * @param request HTTP 요청 객체
+     * @param response HTTP 응답 객체
+     */
     @Override
     public void process(HttpRequest request, HttpResponse response) {
         if (request.getMethod() == HttpMethod.POST) {
@@ -25,6 +39,11 @@ public class MemberSave extends StaticHtmlProcessor {
         super.process(request, response);
     }
 
+    /**
+     * HTTP 요청으로부터 회원 정보를 생성합니다.
+     * @param request HTTP 요청 객체
+     * @return 생성된 회원 정보 객체
+     */
     private User createUser(HttpRequest request) {
         String id = request.getParameter("id");
         String username = request.getParameter("username");
@@ -34,6 +53,11 @@ public class MemberSave extends StaticHtmlProcessor {
         return new User(id, password, username, email);
     }
 
+    /**
+     * 회원가입 결과에 따라 리다이렉트 URL을 생성하고 응답을 반환합니다.
+     * @param response HTTP 응답 객체
+     * @param successJoin 회원가입 성공 여부
+     */
     private void view(HttpResponse response, boolean successJoin) {
         responseHeader302(response, REDIRECT.apply(successJoin));
         response.setMessageBody(CRLF);

--- a/src/main/java/web/MemberSave.java
+++ b/src/main/java/web/MemberSave.java
@@ -3,7 +3,7 @@ package web;
 
 import static utils.HttpConstant.CRLF;
 
-import db.Database;
+import db.UserDatabaseInMemory;
 import http.HttpRequest;
 import http.HttpRequest.HttpMethod;
 import http.HttpResponse;
@@ -14,7 +14,7 @@ public class MemberSave extends StaticHtmlProcessor {
     @Override
     public void process(HttpRequest request, HttpResponse response) {
         if (request.getMethod() == HttpMethod.POST) {
-            Database.addUser(createUser(request));
+            UserDatabaseInMemory.addUser(createUser(request));
 
             responseHeader302(response, "/");
             response.setMessageBody(CRLF);

--- a/src/main/java/web/StaticHtmlProcessor.java
+++ b/src/main/java/web/StaticHtmlProcessor.java
@@ -6,7 +6,20 @@ import http.HttpRequest;
 import http.HttpResponse;
 import java.io.File;
 
+/**
+ * 정적 HTML 파일을 처리하는 클래스입니다.
+ * HTTPProcessor 클래스를 상속하며, 요청에 대한 처리를 담당합니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public class StaticHtmlProcessor extends HttpProcessor {
+
+    /**
+     * HTTP 요청 및 응답에 대한 처리를 수행합니다.
+     * @param request HTTP 요청 객체
+     * @param response HTTP 응답 객체
+     */
     @Override
     public void process(HttpRequest request, HttpResponse response) {
         byte[] resource = getBytes(request);
@@ -17,6 +30,11 @@ public class StaticHtmlProcessor extends HttpProcessor {
         response.flush();
     }
 
+    /**
+     * HTTP 요청으로부터 바이트 배열 형태의 리소스를 가져옵니다.
+     * @param request HTTP 요청 객체
+     * @return 요청에 해당하는 리소스의 바이트 배열
+     */
     public byte[] getBytes(HttpRequest request) {
         String extension = getExtension(request.getRequestURI());
 

--- a/src/main/java/web/UriMapper.java
+++ b/src/main/java/web/UriMapper.java
@@ -8,15 +8,30 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * URI와 그에 해당하는 Processor를 매핑하는 클래스입니다.
+ * Singleton 패턴을 사용하여 인스턴스를 관리합니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public class UriMapper {
     private volatile static UriMapper instance;
     private static final Logger logger = LoggerFactory.getLogger(UriMapper.class);
     private static final Map<String, Processor> URI_MAP = new HashMap<>();
 
+    /**
+     * UriMapper의 생성자입니다.
+     * 기본 URI 매핑을 설정합니다.
+     */
     private UriMapper() {
         setUriMap();
     }
 
+    /**
+     * UriMapper의 인스턴스를 반환합니다.
+     * @return UriMapper 인스턴스
+     */
     public static synchronized UriMapper getInstance() {
         if (instance == null) {
             synchronized (UriMapper.class) {
@@ -38,6 +53,11 @@ public class UriMapper {
         URI_MAP.put("/article", new ArticleWrite());
     }
 
+    /**
+     * 주어진 URI에 해당하는 Processor를 반환합니다.
+     * @param uri URI
+     * @return 해당 URI에 매핑된 Processor의 Optional 객체
+     */
     public Optional<Processor> getProcessor(String uri) {
         if (URI_MAP.containsKey(uri)) {
             return Optional.of(URI_MAP.get(uri));

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -18,6 +18,13 @@ import org.slf4j.LoggerFactory;
 import web.Processor;
 import web.UriMapper;
 
+/**
+ * 클라이언트 요청을 처리하는 클래스입니다.
+ * Runnable을 구현하여 다중 스레드로 처리됩니다.
+ *
+ * @author yelly
+ * @version 1.0
+ */
 public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
     private final Socket connection;
@@ -28,6 +35,9 @@ public class RequestHandler implements Runnable {
         this.connection = connectionSocket;
     }
 
+    /**
+     * 클라이언트 요청을 처리하는 메서드입니다.
+     */
     public void run() {
         logger.debug("New Client Connect! Connected IP : {}, Port : {}", connection.getInetAddress(),
                 connection.getPort());
@@ -51,6 +61,11 @@ public class RequestHandler implements Runnable {
         }
     }
 
+    /**
+     * 요청 URI에 해당하는 Processor를 찾는 메서드입니다.
+     * @param uri 요청 URI
+     * @return 해당 URI에 매핑된 Processor
+     */
     public Optional<Processor> findProcessor(String uri) {
         return UriMapper.getInstance().getProcessor(uri);
     }

--- a/src/main/resources/static/error/404.html
+++ b/src/main/resources/static/error/404.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>404 - ERROR</title>
+    <link href="../reset.css" rel="stylesheet" />
+    <link href="../global.css" rel="stylesheet" />
+    <link href="../main.css" rel="stylesheet" />
+</head>
+<body>
+<div class="container">
+    <header class="header">
+        <a href="/"><img src="../img/signiture.svg" /></a>
+    </header>
+    <div class="wrapper">
+        <h1 class="error__heading">404 - 페이지를 찾을 수 없습니다</h1>
+        <p class="error__message">죄송합니다. 요청하신 페이지를 찾을 수 없습니다.</p>
+        <a class="btn btn_contained btn_size_m" href="/">홈으로 돌아가기</a>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/static/error/405.html
+++ b/src/main/resources/static/error/405.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>405 - ERROR</title>
+    <link href="../reset.css" rel="stylesheet" />
+    <link href="../global.css" rel="stylesheet" />
+    <link href="../main.css" rel="stylesheet" />
+</head>
+<body>
+<div class="container">
+    <header class="header">
+        <a href="/"><img src="../img/signiture.svg" /></a>
+    </header>
+    <div class="wrapper">
+        <h1 class="error__heading">405 - 허용되지 않은 메소드</h1>
+        <p class="error__message">죄송합니다. 이 요청은 허용되지 않습니다.</p>
+        <a class="btn btn_contained btn_size_m" href="/">홈으로 돌아가기</a>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/static/error/500.html
+++ b/src/main/resources/static/error/500.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>500 - SERVER ERROR</title>
+    <link href="../reset.css" rel="stylesheet" />
+    <link href="../global.css" rel="stylesheet" />
+    <link href="../main.css" rel="stylesheet" />
+</head>
+<body>
+<div class="container">
+    <header class="header">
+        <a href="/"><img src="../img/signiture.svg" /></a>
+    </header>
+    <div class="wrapper">
+        <h1 class="error__heading">500 - 내부 서버 오류</h1>
+        <p class="error__message">죄송합니다. 서버에서 처리할 수 없는 문제가 발생했습니다.</p>
+        <a class="btn btn_contained btn_size_m" href="/">홈으로 돌아가기</a>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/static/global.css
+++ b/src/main/resources/static/global.css
@@ -213,3 +213,16 @@
   opacity: 0;
   cursor: pointer;
 }
+
+.error__heading {
+  font-size: 24px;
+  font-weight: bold;
+  color: #333333; /* 또는 원하는 색상 */
+  margin-bottom: 10px;
+}
+
+.error__message {
+  font-size: 18px;
+  color: #333333; /* 또는 원하는 색상 */
+  margin-bottom: 20px;
+}

--- a/src/main/resources/static/registration/failed.html
+++ b/src/main/resources/static/registration/failed.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <link href="../reset.css" rel="stylesheet"/>
+    <link href="../global.css" rel="stylesheet"/>
+</head>
+<body>
+<div class="container">
+    <header class="header">
+        <a href="/"><img src="../img/signiture.svg"/></a>
+        <ul class="header__menu">
+            <li class="header__menu__item">
+                <a class="btn btn_contained btn_size_s" href="/login">로그인</a>
+            </li>
+            <li class="header__menu__item">
+                <a class="btn btn_ghost btn_size_s" href="/registration">
+                    회원 가입
+                </a>
+            </li>
+        </ul>
+    </header>
+    <div class="page">
+        <h2 class="page-title">회원가입</h2>
+        <form class="form" action="" method="post">
+            <p style="color:red; padding-top: 10px; padding-bottom: 10px">이미 존재하는 아이디 입니다.</p>
+            <div class="textfield textfield_size_s">
+                <p class="title_textfield">아이디</p>
+                <input
+                        class="input_textfield"
+                        placeholder="아이디를 입력해주세요"
+                        name="id"
+                />
+            </div>
+            <div class="textfield textfield_size_s">
+                <p class="title_textfield">닉네임</p>
+                <input
+                        class="input_textfield"
+                        placeholder="닉네임을 입력해주세요"
+                        name="username"
+                />
+            </div>
+            <div class="textfield textfield_size_s">
+                <p class="title_textfield">이메일</p>
+                <input
+                        class="input_textfield"
+                        type="email"
+                        placeholder="이메일을 입력해주세요"
+                        name="email"
+                />
+            </div>
+            <div class="textfield textfield_size_s">
+                <p class="title_textfield">비밀번호</p>
+                <input
+                        class="input_textfield"
+                        type="password"
+                        placeholder="비밀번호를 입력해주세요"
+                        name="password"
+                />
+            </div>
+            <button
+                    id="registration-btn"
+                    class="btn btn_contained btn_size_m"
+                    style="margin-top: 24px"
+                    type="submit"
+            >
+                회원가입
+            </button>
+        </form>
+    </div>
+</div>
+</body>
+</html>

--- a/src/test/java/db/ArticleDatabaseH2Test.java
+++ b/src/test/java/db/ArticleDatabaseH2Test.java
@@ -1,0 +1,95 @@
+package db;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import model.Article;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ArticleDatabaseH2Test {
+
+    private final ArticleDatabaseH2 db = new ArticleDatabaseH2();
+
+    @AfterEach
+    void delete() {
+        db.delete(1L);
+        db.delete(2L);
+        db.resetIdWithOne();
+    }
+
+    @DisplayName("게시물을 데이터베이스에 추가하면 자동으로 id가 0부터 1씩 증가한다")
+    @Test
+    void addArticle_auto_increment_id() throws SQLException {
+        // given
+        String body = "This is a test text";
+        String createdBy = "yelly";
+        LocalDateTime createdAt = LocalDateTime.of(2024, 3, 30, 0, 0, 0);
+        String imagePath = "";
+
+        Article article = new Article(body, createdBy, createdAt, imagePath);
+
+        // when
+        Article saveArticle = db.add(article);
+
+        // then
+        assertThat(saveArticle.id()).isEqualTo(1L);
+        assertThat(saveArticle.body()).isEqualTo(body);
+        assertThat(saveArticle.createdBy()).isEqualTo(createdBy);
+        assertThat(saveArticle.createdAt()).isEqualTo(createdAt);
+        assertThat(saveArticle.imagePath()).isEqualTo(imagePath);
+    }
+
+    @DisplayName("id가 2에 해당하고 userId가 monster 인 게시물을 찾을 수 있다")
+    @Test
+    void findArticleById() throws SQLException {
+        // given
+        String body = "This is a test text";
+        String createdByYelly = "yelly";
+        String createdByMonster = "monster";
+        LocalDateTime createdAt = LocalDateTime.of(2024, 3, 30, 0, 0, 0);
+        String imagePath = "";
+
+        Article article1 = new Article(body, createdByYelly, createdAt, imagePath);
+        Article article2 = new Article(body, createdByMonster, createdAt, imagePath);
+
+        /* DB에 2개 저장 */
+        db.add(article1);
+        db.add(article2);
+
+        // when
+        Optional<Article> findArticle = db.findById(2L);
+
+        // then
+        assertThat(findArticle).isPresent();
+        assertThat(findArticle.get()).extracting("createdBy").isEqualTo("monster");
+    }
+
+    @DisplayName("yelly 유저의 게시물 2개 중 가장 최신 게시물 12월 31일자 게시물 1개를 찾을 수 있다")
+    @Test
+    void findLatest() throws SQLException {
+        // given
+        String body = "This is a test text";
+        String createdBy = "yelly";
+        LocalDateTime createdAt1 = LocalDateTime.of(2024, 1, 1, 0, 0, 0);
+        LocalDateTime createdAt2 = LocalDateTime.of(2024, 12, 31, 0, 0, 0);
+        String imagePath = "";
+
+        Article article1 = new Article(body, createdBy, createdAt1, imagePath); // 가장 오래된 게시물
+        Article article2 = new Article(body, createdBy, createdAt2, imagePath); // 가장 최신 게시물
+
+        /* DB에 2개 저장 */
+        db.add(article1);
+        db.add(article2);
+
+        // when
+        Optional<Article> latestArticle = db.findLatest("yelly");
+
+        // then
+        assertThat(latestArticle).isPresent();
+        assertThat(latestArticle.get()).extracting("createdAt").isEqualTo(createdAt2);
+    }
+}

--- a/src/test/java/db/ArticleDatabaseInMemoryTest.java
+++ b/src/test/java/db/ArticleDatabaseInMemoryTest.java
@@ -10,11 +10,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class ArticleDatabaseTest {
+class ArticleDatabaseInMemoryTest {
 
     @AfterEach
     void clear() {
-        ArticleDatabase.clear();
+        ArticleDatabaseInMemory.clear();
     }
 
     @DisplayName("Article 하나를 저장하면 데이터베이스에 key가 1부터 저장된다")
@@ -27,8 +27,8 @@ class ArticleDatabaseTest {
         Article testArticle1 = new Article("test1", "yelly", createdAt1, null);
 
         // when
-        ArticleDatabase.add(testArticle1);
-        Article firstSaveArticle = ArticleDatabase.findById(1);
+        ArticleDatabaseInMemory.add(testArticle1);
+        Article firstSaveArticle = ArticleDatabaseInMemory.findById(1);
 
         // then
         assertThat(firstSaveArticle.body()).isEqualTo("test1");
@@ -47,10 +47,10 @@ class ArticleDatabaseTest {
         Article testArticle2 = new Article("test2", "trolli", createdAt2, null);
 
         // when
-        ArticleDatabase.add(testArticle1);
-        ArticleDatabase.add(testArticle2);
-        Article firstSaveArticle = ArticleDatabase.findById(1);
-        Article secondSaveArticle = ArticleDatabase.findById(2);
+        ArticleDatabaseInMemory.add(testArticle1);
+        ArticleDatabaseInMemory.add(testArticle2);
+        Article firstSaveArticle = ArticleDatabaseInMemory.findById(1);
+        Article secondSaveArticle = ArticleDatabaseInMemory.findById(2);
 
         // then
         assertThat(firstSaveArticle.body()).isEqualTo("test1");
@@ -72,11 +72,11 @@ class ArticleDatabaseTest {
         // 가장 최신 글
         Article testArticle2 = new Article("latest", "yelly", latestTime, null);
 
-        ArticleDatabase.add(testArticle1);
-        ArticleDatabase.add(testArticle2);
+        ArticleDatabaseInMemory.add(testArticle1);
+        ArticleDatabaseInMemory.add(testArticle2);
 
         // when
-        Article latest = ArticleDatabase.findLatest("yelly").get();
+        Article latest = ArticleDatabaseInMemory.findLatest("yelly").get();
 
         // then
         assertThat(latest.body()).isEqualTo("latest");
@@ -88,7 +88,7 @@ class ArticleDatabaseTest {
     @Test
     void findLatest_fail() {
         // when
-        Optional<Article> latest = ArticleDatabase.findLatest("yelly");
+        Optional<Article> latest = ArticleDatabaseInMemory.findLatest("yelly");
 
         // then
         assertThat(latest.isEmpty()).isTrue();

--- a/src/test/java/db/UserDatabaseH2Test.java
+++ b/src/test/java/db/UserDatabaseH2Test.java
@@ -1,0 +1,78 @@
+package db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+import model.User;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class UserDatabaseH2Test {
+
+    private final UserDatabaseH2 db = new UserDatabaseH2();
+
+    @AfterEach
+    void delete() {
+        db.delete("tester");
+        db.delete("tester2");
+    }
+
+    @DisplayName("'tester'라는 아이디의 유저를 H2 데이터베이스에 저장할 수 있다")
+    @Test
+    void add() {
+        // given
+        User user = new User("tester", "123", "testUser", "test@test.com");
+
+        // when
+        db.add(user);
+        Optional<User> optionalUser = db.findById("tester");
+
+        // then
+        assertThat(optionalUser.isPresent()).isTrue();
+        assertThat(optionalUser.get()).isEqualTo(user);
+    }
+
+    @DisplayName("'tester2'라는 아이디를 가진 유저를 찾을 수 있다")
+    @Test
+    void findUserById_success() {
+        // given
+        User user = new User("tester2", "123", "testUser", "test@test.com");
+        db.add(user);
+
+        // when
+        Optional<User> optionalUser = db.findById("tester2");
+
+        // then
+        assertThat(optionalUser.isPresent()).isTrue();
+        assertThat(optionalUser.get()).isEqualTo(user);
+    }
+
+    @DisplayName("'noUser'라는 존재하지 않는 아이디로 유저를 찾을 수 없다")
+    @Test
+    void findUserById_not_found() {
+        // when
+        Optional<User> optionalUser = db.findById("noUser");
+
+        // then
+        assertThat(optionalUser.isEmpty()).isTrue();
+    }
+
+    @DisplayName("'tester', 'tester2' 아이디를 갖는 모든 유저를 찾을 수 있다")
+    @Test
+    void findAll() {
+        // given
+        User tester1 = new User("tester", "123", "yelly", "yelly@test.com");
+        User tester2 = new User("tester2", "123", "jelly", "jelly@test.com");
+        db.add(tester1);
+        db.add(tester2);
+
+        // when
+        List<User> users = db.findAll();
+
+        // then
+        assertThat(users.size()).isEqualTo(2);
+        assertThat(users).contains(tester1, tester2);
+    }
+}

--- a/src/test/java/db/UserDatabaseInMemoryTest.java
+++ b/src/test/java/db/UserDatabaseInMemoryTest.java
@@ -8,11 +8,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class DatabaseTest {
+class UserDatabaseInMemoryTest {
 
     @BeforeEach
     void resetDatabase() {
-        Database.clear();
+        UserDatabaseInMemory.clear();
     }
 
     @DisplayName("testId를 가진 User 객체를 추가하면 데이트베이스에 Key가 User의 id로 추가된다")
@@ -22,10 +22,10 @@ class DatabaseTest {
         User user = new User("testId", "1234", "testName", "testEmail");
 
         // when
-        Database.addUser(user);
+        UserDatabaseInMemory.addUser(user);
 
         // then
-        assertThat(Database.findUserById("testId").get().getUserId()).isEqualTo("testId");
+        assertThat(UserDatabaseInMemory.findUserById("testId").get().getUserId()).isEqualTo("testId");
     }
 
     @DisplayName("User의 id로 User르 찾을 수 있다")
@@ -35,12 +35,12 @@ class DatabaseTest {
         User userA = new User("userA", "1234", "testA", "testEmailA");
         User userB = new User("userB", "7890", "testB", "testEmailB");
 
-        Database.addUser(userA);
-        Database.addUser(userB);
+        UserDatabaseInMemory.addUser(userA);
+        UserDatabaseInMemory.addUser(userB);
 
         // when
-        User findUserA = Database.findUserById("userA").get();
-        User findUserB = Database.findUserById("userB").get();
+        User findUserA = UserDatabaseInMemory.findUserById("userA").get();
+        User findUserB = UserDatabaseInMemory.findUserById("userB").get();
 
         // then
         assertThat(findUserA).isEqualTo(userA);
@@ -58,12 +58,12 @@ class DatabaseTest {
         User userB = new User("userB", "7890", "testB", "testEmailB");
         User userC = new User("userC", "5555", "testC", "testEmailC");
 
-        Database.addUser(userA);
-        Database.addUser(userB);
-        Database.addUser(userC);
+        UserDatabaseInMemory.addUser(userA);
+        UserDatabaseInMemory.addUser(userB);
+        UserDatabaseInMemory.addUser(userC);
 
         // when
-        Collection<User> users = Database.findAll();
+        Collection<User> users = UserDatabaseInMemory.findAll();
 
         // then
         assertThat(users.size()).isEqualTo(3);

--- a/src/test/java/login/LoginManagerTest.java
+++ b/src/test/java/login/LoginManagerTest.java
@@ -2,7 +2,7 @@ package login;
 
 import static org.assertj.core.api.Assertions.*;
 
-import db.Database;
+import db.UserDatabaseInMemory;
 import java.util.Optional;
 import model.User;
 import org.junit.jupiter.api.AfterEach;
@@ -17,12 +17,12 @@ class LoginManagerTest {
 
     @BeforeEach
     void setUp() {
-        Database.addUser(testUser);
+        UserDatabaseInMemory.addUser(testUser);
     }
 
     @AfterEach
     void clear() {
-        Database.clear();
+        UserDatabaseInMemory.clear();
     }
 
     @DisplayName("등록된 유저의 아이디 yelly, 패스워드를 yelly123에 대해 로그인에 성공하면 해당 유저를 반환한다")

--- a/src/test/java/manager/UserManagerTest.java
+++ b/src/test/java/manager/UserManagerTest.java
@@ -1,28 +1,33 @@
 package manager;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import db.UserDatabaseInMemory;
+import java.util.Collection;
 import java.util.Optional;
 import model.User;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 class UserManagerTest {
     private final UserManager userManager = new UserManager();
-    private final User testUser = new User("yelly", "yelly123", "yelly", "yelly@code.com");;
+    private final User testUser = new User("yelly", "yelly123", "yelly", "yelly@code.com");
 
     @BeforeEach
     void setUp() {
-        UserDatabaseInMemory.addUser(testUser);
+        userManager.join(testUser);
     }
 
     @AfterEach
     void clear() {
-        UserDatabaseInMemory.clear();
+        userManager.deleteUser(testUser);
+
+        // 임시 테스터
+        User tempTester = new User("testId", "123", "tester", "test@test.com");
+        userManager.deleteUser(tempTester);
     }
 
     @DisplayName("등록된 유저의 아이디 yelly, 패스워드를 yelly123에 대해 로그인에 성공하면 해당 유저를 반환한다")
@@ -57,5 +62,49 @@ class UserManagerTest {
 
         // then
         assertThat(optionalUser.isEmpty()).isTrue();
+    }
+
+    @DisplayName("회원가입을 처음하는 tester 유저에 대해 회원가입 결과는 참이다")
+    @Test
+    void join_success() {
+        // given
+        User tester = new User("testId", "123", "tester", "test@test.com");
+
+        // when
+        boolean result = userManager.join(tester);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @DisplayName("이미 존재하는 yelly 라는 아이디로 회원가입 시도하면 결과는 거짓이다")
+    @Test
+    void join_fail() {
+        // given
+        User tester = new User("yelly", "123", "yelly", "yelly@test.com");
+
+        // when
+        userManager.join(tester);
+        boolean result = userManager.join(tester); // 중복 회원가입
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @DisplayName("회원가입 되어있는 2명을 모두 찾을 수 있다")
+    @Test
+    void findAllUser_size_2() {
+        // given
+        User tester = new User("testId", "123", "yelly", "yelly@test.com");
+        userManager.join(tester);
+
+        // when
+        Collection<User> allUser = userManager.findAllUser();
+
+        // then
+        assertThat(allUser).size().isEqualTo(2);
+        assertThat(allUser).contains(
+                testUser, tester
+        );
     }
 }

--- a/src/test/java/manager/UserManagerTest.java
+++ b/src/test/java/manager/UserManagerTest.java
@@ -1,4 +1,4 @@
-package login;
+package manager;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -11,8 +11,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-class LoginManagerTest {
-    private final LoginManager loginManager = new LoginManager();
+class UserManagerTest {
+    private final UserManager userManager = new UserManager();
     private final User testUser = new User("yelly", "yelly123", "yelly", "yelly@code.com");;
 
     @BeforeEach
@@ -30,7 +30,7 @@ class LoginManagerTest {
     @CsvSource(value = "yelly, yelly123")
     void login_success(String id, String password) {
         // when
-        Optional<User> optionalUser = loginManager.login(id, password);
+        Optional<User> optionalUser = userManager.login(id, password);
 
         // then
         assertThat(optionalUser.isPresent()).isTrue();
@@ -42,7 +42,7 @@ class LoginManagerTest {
     @CsvSource(value = "yelly, fail")
     void login_fail_when_mistake_typing_password(String id, String failPassword) {
         // when
-        Optional<User> optionalUser = loginManager.login(id, failPassword);
+        Optional<User> optionalUser = userManager.login(id, failPassword);
 
         // then
         assertThat(optionalUser.isEmpty()).isTrue();
@@ -53,7 +53,7 @@ class LoginManagerTest {
     @CsvSource(value = "noRegister, yelly123")
     void login_fail_when_find_unregistered_user(String noRegisteredId, String password) {
         // when
-        Optional<User> optionalUser = loginManager.login(noRegisteredId, password);
+        Optional<User> optionalUser = userManager.login(noRegisteredId, password);
 
         // then
         assertThat(optionalUser.isEmpty()).isTrue();

--- a/src/test/java/model/ArticleTest.java
+++ b/src/test/java/model/ArticleTest.java
@@ -2,6 +2,7 @@ package model;
 
 import static org.assertj.core.api.Assertions.*;
 
+import db.ArticleDatabaseInMemory;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
## 구현 내용
- `데이터베이스`와 `HtmlProcessor` 사이에 서비스 계층을 구현했습니다.
  - 서비스 계층의 `UserManager`, `ArticleManager` 클래스만 직접 데이터베이스 커넥션을 얻습니다.
  - 이로써 `HtmlProcessor`는 데이터베이스의 구현체에 의존하지 않습니다.

- H2 데이터베이스와 연동되도록 구현했습니다.
  - 서비스 계층(Manager 클래스)이 `Database` 인터페이스를 참조하게 하고, `DataSourceUtil`를 이용한 `Database` 인터페이스를 구현체를 이용해 DIP를 적용했습니다.

- 404, 405, 500 등 Http Status에 따라 다른 에러 페이지가 보여지도록 구현했습니다.
  - `ResponseErrorUtil`에게 Http Status 코드에 맞는 `ErrorHtmlProcessor`를 호출하도록 상위 객체인 `ReqeustHandler`로부터 위임받습니다.
  - 처리할 수 없는 URL은 404.html 을 반환합니다.
  - 허용되지 않는 HTTP 메서드는 405.html 을 반환합니다.
  - 데이터베이스 연결 에러 등 서버 내부 에러는 500.html 를 반환합니다.

- javaDoc 작성 후 배포 완료했습니다.
  - [javaDoc (github.io)](https://yeriimii.github.io/docs/be-was-neon/)

- 피드백 주신 이미지 처리 부분의 성능을 개선했습니다. (기존 16,996ms -> 20ms)
![피드백](https://github.com/codesquad-members-2024/be-was-neon/assets/87357932/27fe42d1-450f-4d1d-ba52-a278b69c39ec)
  - 힌트로 주신 IDE의 프로파일링 기능을 이용해 병목이 발생하는 부분을 찾았습니다. (7.2mb 기준 16996ms 소요)
  ![병목 발생 부분](https://github.com/codesquad-members-2024/be-was-neon/assets/87357932/f142ca6a-2fba-4edd-b2a9-b1ff4d28be99)
  - 병목이 발생한 부분은 예상외로 정규표현식을 사용한 부분이 아니라 `while loop 탈출 조건을 테스트하는 부분`인 `ByteArrayOutputStream`을 `String`으로 변환시키는 부분이었습니다.
  - 이 부분을 개선한 결과, 7.2mb 파일 기준으로 기존 `16996ms`에서 `20ms`로 `849배` 빠르게 처리하도록 개선했습니다.
  ![병목 해결](https://github.com/codesquad-members-2024/be-was-neon/assets/87357932/41940aba-cbab-426d-8502-2a637cfdcdce)

## 고민 사항
- 이미지 처리 부분을 개선시키기 위해 2가지를 고민했습니다.
  1. 버퍼의 크기 증가 : 8kb -> 1mb
  2. `String` 변환을 최소화
- 디버깅 결과 버퍼의 크기를 1mb 정도로 증가 시키면 처리 속도가 `1,100ms`로 낮아지긴 하지만, 그만큼 할당되는 메모리가 기하급수적으로 증가한다는 문제가 있었습니다.
- 대신 `String` 변환을 최소화하면 가독성이 기존 코드보다 떨어지는 대신 처리 속도가 `20ms` 정도로 훨씬 더 낮아질 뿐만아니라 할당되는 메모리도 적게 가져갈 수 있다는 이점이 있었습니다.
- 고민 끝에 가독성을 조금 떨어뜨리는 대신 이미지 처리 속도와 사용 메모리를 적게 쓰는 방법을 선택해서 고민을 해결했습니다.
